### PR TITLE
Improve VirusTotal verification flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ Clonar el repositorio en una carpeta llamada appventurers
 - Lo primero que debe hacer es importar la base de datos, crear un usuario con su contraseña encriptada en Argon2ID, configurar los archivos que hacen referencia a la API Key de VirusTotal e iniciar sesión.
 - Tras iniciar sesión se le redigirirá a la tabla de administración donde podrá buscar puestos, cambiar de idioma, editar un puesto o una traducción del mismo, cambiar su contraseña o ver un mapa de las ameas, naves y murallones
 
+### Verificación de imágenes con VirusTotal
+
+Para evitar que se suban archivos maliciosos se integra una comprobación automática con la API de VirusTotal:
+
+1. **Configurar la clave**: cree un archivo `virustotal_api_key.php` en la raíz del proyecto con la constante `VIRUSTOTAL_API_KEY` que contenga su clave de API.
+2. **Flujo de validación**: cuando el formulario de edición sube una imagen, el frontend llama a `helpers/verify_malicious_photo.php`, que reenvía el archivo temporal a VirusTotal usando `curl_file_create`, manteniendo activos `CURLOPT_SSL_VERIFYPEER` y `CURLOPT_SSL_VERIFYHOST` y aplicando timeouts razonables.
+3. **Respuesta homogénea**: el endpoint devuelve un JSON con los campos `success`, `is_malicious` y `message`. La lógica de `admin/js/helpers/verify_malicious_photo.js` espera exactamente esta estructura y muestra mensajes claros ante fallos de conectividad o detecciones.
+4. **Validación en el servidor**: además del filtro en el navegador, `helpers/update_stalls.php` invoca la misma comprobación antes de aceptar definitivamente la imagen.
+
+Si no se define la clave de la API o el servicio devuelve un error, el usuario recibirá un mensaje explicativo y la imagen no se subirá.
+
 
 ### Página de inicio de sesión
 ![Captura de pantalla (7)](https://github.com/user-attachments/assets/f28819db-32a8-478c-845b-8734242db901)

--- a/admin/js/edit_admin.js
+++ b/admin/js/edit_admin.js
@@ -6,7 +6,12 @@ const formulario = document.getElementById('formulario-editar');
 let errorExist = false;
 let errorMessages = '';
 
-formulario.addEventListener('submit', function (e) {
+formulario.addEventListener('submit', async function (e) {
+    e.preventDefault();
+
+    errorExist = false;
+    errorMessages = '';
+
     // Campos obligatorios
     let caseta = document.getElementById('caseta').value;
     let tipoUnity = document.getElementById('tipo-unity').value;
@@ -147,18 +152,21 @@ formulario.addEventListener('submit', function (e) {
     // Verificar si se ha subido una foto y, en caso de que se haya subido, si es maliciosa
     const foto = document.getElementById('imagen') ? document.getElementById('imagen').files[0] : '';
     if (foto !== '') {
-        verifyMaliciousPhoto(foto).then(esMaliciosa => {
-            if (esMaliciosa) {
-                e.preventDefault();
-                alert('La foto es maliciosa. Por favor, desinfecte el archivo o pida ayuda para desinfectarlo o saque una foto nueva tras desinfectar el dispositivo.');
-                return;
-            }
-        });
+        const verification = await verifyMaliciousPhoto(foto);
+
+        if (!verification.success) {
+            alert(verification.message || 'No se pudo verificar la imagen.');
+            return;
+        }
+
+        if (verification.isMalicious) {
+            alert(verification.message || 'La foto es maliciosa. Por favor, desinfecte el archivo o pida ayuda para desinfectarlo o saque una foto nueva tras desinfectar el dispositivo.');
+            return;
+        }
     }
 
     // Si hay errores, no enviar formulario y mostrar mensajes de error creando un div con los mensajes
     if (errorExist) {
-        e.preventDefault();
         const div = document.createElement('div');
         div.innerHTML = errorMessages;
         formulario.insertAdjacentElement('afterend', div);
@@ -166,4 +174,5 @@ formulario.addEventListener('submit', function (e) {
     }
 
     // Enviar formulario
+    formulario.submit();
 });

--- a/helpers/update_stalls.php
+++ b/helpers/update_stalls.php
@@ -25,10 +25,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
 
         // Verificar si la imagen es maliciosa
-        $maliciosa = check_virus_total($_FILES['imagen']['tmp_name']);
+        $scanResult = check_virus_total($_FILES['imagen']['tmp_name']);
 
-        if ($maliciosa) {
-            throw new Exception("La imagen subida es maliciosa. Por favor, desinféctela y suba una imagen válida. Puede ser necesario desinfectar el dispositivo desde el que se capturó o el dispositivo desde el que se subió la imagen.");
+        if (!$scanResult['success']) {
+            throw new Exception($scanResult['message']);
+        }
+
+        if ($scanResult['is_malicious']) {
+            throw new Exception($scanResult['message'] ?: "La imagen subida es maliciosa. Por favor, desinféctela y suba una imagen válida. Puede ser necesario desinfectar el dispositivo desde el que se capturó o el dispositivo desde el que se subió la imagen.");
         }
 
         $is_imagen = save_image($_FILES['imagen'], $caseta);


### PR DESCRIPTION
## Summary
- Refactor `helpers/verify_malicious_photo.php` to use `curl_file_create`, keep SSL verification active, add timeouts, and expose a JSON endpoint with detailed error messages.
- Update server-side and frontend consumers to handle the richer VirusTotal response, ensuring form submission waits for the scan result.
- Document the end-to-end verification flow and API key requirement in the README.

## Testing
- php -l helpers/verify_malicious_photo.php
- php -l helpers/update_stalls.php

------
https://chatgpt.com/codex/tasks/task_e_68d28ce9ca048325ac4d52dfdcab181e