### PR TITLE
Load database config from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Configuración de la conexión a la base de datos
+PRACEAR_DB_HOST=localhost
+PRACEAR_DB_USER=root
+PRACEAR_DB_PASSWORD=
+PRACEAR_DB_NAME=pracear

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ virustotal_api_key.php
 wolfram_alpha_api_key.php
 admin/js/helpers/api_key.js
 wolfram_alpha_app_id.php
+.env

--- a/config/env_loader.php
+++ b/config/env_loader.php
@@ -1,0 +1,71 @@
+<?php
+
+if (!function_exists('load_project_env')) {
+    /**
+     * Load key/value pairs from a .env style file.
+     */
+    function load_project_env(string $baseDir, string $fileName = '.env'): array
+    {
+        $path = rtrim($baseDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $fileName;
+
+        if (!is_readable($path)) {
+            return [];
+        }
+
+        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if ($lines === false) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || $line[0] === '#') {
+                continue;
+            }
+
+            $delimiterPosition = strpos($line, '=');
+            if ($delimiterPosition === false) {
+                continue;
+            }
+
+            $key = trim(substr($line, 0, $delimiterPosition));
+            $value = trim(substr($line, $delimiterPosition + 1));
+
+            if ($key === '') {
+                continue;
+            }
+
+            if ($value !== '') {
+                $firstCharacter = $value[0];
+                $lastCharacter = substr($value, -1);
+                if ((($firstCharacter === '"' && $lastCharacter === '"') || ($firstCharacter === "'" && $lastCharacter === "'")) && strlen($value) >= 2) {
+                    $value = substr($value, 1, -1);
+                }
+            }
+
+            $values[$key] = $value;
+        }
+
+        return $values;
+    }
+}
+
+if (!function_exists('get_env_value')) {
+    /**
+     * Retrieve an environment variable. Environment variables take precedence over file values.
+     */
+    function get_env_value(string $key, array $fileValues, $default = null)
+    {
+        $environmentValue = getenv($key);
+        if ($environmentValue !== false) {
+            return $environmentValue;
+        }
+
+        if (array_key_exists($key, $fileValues)) {
+            return $fileValues[$key];
+        }
+
+        return $default;
+    }
+}

--- a/connection.php
+++ b/connection.php
@@ -2,28 +2,40 @@
 
 require_once('./constants.php');
 
-$conexion = "Sin conexión";
-
+$conexion = null;
 
 try {
-    // Habilitar excepciones para errores de mysqli
     mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
-    // Intentar la conexión
-    $conexion = new mysqli($servidor_bd, $usuario, $clave, $bd);
+    $missingConfiguration = [];
 
+    if (!is_string($servidor_bd) || $servidor_bd === '') {
+        $missingConfiguration[] = 'PRACEAR_DB_HOST';
+    }
 
-    // Si la conexión es exitosa
-    // echo "Conexión exitosa a la base de datos";
+    if (!is_string($usuario) || $usuario === '') {
+        $missingConfiguration[] = 'PRACEAR_DB_USER';
+    }
 
-} catch (mysqli_sql_exception $e) {
-    // Manejo de la excepción
-    echo "Error en la conexión: " . $e->getMessage();
-    // Aquí podrías registrar el error en un archivo de logs o realizar otra acción.
-} finally {
-    // Cerrar la conexión si fue exitosa
-    // if (isset($conexion) && $conexion->connect_error == null) {
-    //     $conexion->close();
-    // }
+    if (!is_string($bd) || $bd === '') {
+        $missingConfiguration[] = 'PRACEAR_DB_NAME';
+    }
+
+    if (!empty($missingConfiguration)) {
+        throw new RuntimeException('Faltan variables de entorno requeridas: ' . implode(', ', $missingConfiguration));
+    }
+
+    $password = $clave === null ? '' : (string) $clave;
+
+    $conexion = new mysqli($servidor_bd, $usuario, $password, $bd);
+    $conexion->set_charset('utf8mb4');
+} catch (RuntimeException $exception) {
+    error_log($exception->getMessage());
+    http_response_code(500);
+    exit('La configuración de la base de datos no está completa. Póngase en contacto con la persona administradora.');
+} catch (mysqli_sql_exception $exception) {
+    error_log('Error al conectar con la base de datos: ' . $exception->getMessage());
+    http_response_code(500);
+    exit('No se ha podido establecer conexión con la base de datos. Inténtelo de nuevo más tarde.');
 }
 

--- a/constants.php
+++ b/constants.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/config/env_loader.php';
+
 define('DIRNAME', dirname(__FILE__));
 define('ADMIN', DIRNAME . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR);
 define('ASSETS', DIRNAME . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR);
@@ -79,9 +81,17 @@ $subdominio = "appventurers";
 
 
 // Datos de conexión a la BBDD
+$envVariables = load_project_env(DIRNAME);
 
-$servidor_bd = $_SERVER['SERVER_NAME'] == 'localhost' ? 'localhost' : 'db5016239277.hosting-data.io';
-$usuario = $_SERVER['SERVER_NAME'] == 'localhost' ? 'root' : 'dbu2777657';
-$clave = $_SERVER['SERVER_NAME'] == 'localhost' ? '' : 'apdtmMdp27042304()';
-$bd = 'dbs13217995';
+$servidor_bd = get_env_value('PRACEAR_DB_HOST', $envVariables);
+$usuario = get_env_value('PRACEAR_DB_USER', $envVariables);
+$clave = get_env_value('PRACEAR_DB_PASSWORD', $envVariables);
+$bd = get_env_value('PRACEAR_DB_NAME', $envVariables);
+
+define('DB_CONFIG', [
+    'host' => $servidor_bd,
+    'user' => $usuario,
+    'password' => $clave,
+    'database' => $bd,
+]);
 

--- a/unity/connection.php
+++ b/unity/connection.php
@@ -1,18 +1,50 @@
 <?php
-include 'constants.php';
+
+require_once 'constants.php';
+
 $conn = null;
 
 try {
-    $conn = mysqli_connect(DB_SERVER, DB_USER, DB_PASS, DB_DATABASE);
-    if (!$conn) {
-        throw new Exception("Conexión fallida: " . mysqli_connect_error());
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+    $missingConfiguration = [];
+
+    if (!is_string($servidor_bd) || $servidor_bd === '') {
+        $missingConfiguration[] = 'PRACEAR_DB_HOST';
     }
 
-} catch (Exception $e) {
+    if (!is_string($usuario) || $usuario === '') {
+        $missingConfiguration[] = 'PRACEAR_DB_USER';
+    }
+
+    if (!is_string($bd) || $bd === '') {
+        $missingConfiguration[] = 'PRACEAR_DB_NAME';
+    }
+
+    if (!empty($missingConfiguration)) {
+        throw new RuntimeException('Faltan variables de entorno requeridas: ' . implode(', ', $missingConfiguration));
+    }
+
+    $password = $clave === null ? '' : (string) $clave;
+
+    $conn = new mysqli($servidor_bd, $usuario, $password, $bd);
+    $conn->set_charset('utf8mb4');
+} catch (RuntimeException $exception) {
+    error_log($exception->getMessage());
+    http_response_code(500);
     echo json_encode([
-        "codigo" => 400,
-        "mensaje" => "connection.php: Error intentando conectar",
-        "respuesta" => $e->getMessage()
+        'codigo' => 500,
+        'mensaje' => 'La configuración de la base de datos no está completa.',
+        'respuesta' => 'Contacte con la persona administradora para revisar la configuración.',
+    ]);
+    exit;
+} catch (mysqli_sql_exception $exception) {
+    error_log('Error al conectar con la base de datos: ' . $exception->getMessage());
+    http_response_code(500);
+    echo json_encode([
+        'codigo' => 500,
+        'mensaje' => 'No se ha podido establecer conexión con la base de datos.',
+        'respuesta' => 'Inténtelo de nuevo más tarde.',
     ]);
     exit;
 }

--- a/unity/constants.php
+++ b/unity/constants.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/../config/env_loader.php';
+
 // Detectar la ruta raíz del proyecto dinámicamente
 define('DIRNAME', dirname(__FILE__)); // Directorio donde está este archivo
 $projectRoot = str_replace('\\', '/', str_replace($_SERVER['DOCUMENT_ROOT'], '', DIRNAME)); // Ruta relativa
@@ -75,7 +77,18 @@ define('UNITY_TYPE', [
 ]);
 
 // Datos de conexión a la BBDD
-$servidor_bd = $_SERVER['SERVER_NAME'] == 'localhost' ? 'localhost' : 'db5016239277.hosting-data.io';
-$usuario = $_SERVER['SERVER_NAME'] == 'localhost' ? 'root' : 'dbu2777657';
-$clave = $_SERVER['SERVER_NAME'] == 'localhost' ? '' : 'apdtmMdp27042304()';
-$bd = 'dbs13217995';
+$envVariables = load_project_env(dirname(__DIR__));
+
+$servidor_bd = get_env_value('PRACEAR_DB_HOST', $envVariables);
+$usuario = get_env_value('PRACEAR_DB_USER', $envVariables);
+$clave = get_env_value('PRACEAR_DB_PASSWORD', $envVariables);
+$bd = get_env_value('PRACEAR_DB_NAME', $envVariables);
+
+if (!defined('DB_CONFIG')) {
+    define('DB_CONFIG', [
+        'host' => $servidor_bd,
+        'user' => $usuario,
+        'password' => $clave,
+        'database' => $bd,
+    ]);
+}


### PR DESCRIPTION
## Summary
- load database credentials from environment variables or a local .env file via a shared loader
- harden connection scripts and helpers to validate configuration and emit generic error messages
- add an example .env file and ignore real configuration secrets

## Testing
- for file in constants.php connection.php helpers/verify_strong_password.php unity/constants.php unity/connection.php config/env_loader.php; do php -l "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68d28cad49688325a0edf278c79eae97