### PR TITLE
Configurar constantes de base de datos en Unity

### DIFF
--- a/unity/connection.php
+++ b/unity/connection.php
@@ -1,18 +1,23 @@
 <?php
 include 'constants.php';
+
 $conn = null;
 
 try {
-    $conn = mysqli_connect(DB_SERVER, DB_USER, DB_PASS, DB_DATABASE);
-    if (!$conn) {
-        throw new Exception("Conexión fallida: " . mysqli_connect_error());
-    }
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
-} catch (Exception $e) {
+    $conn = mysqli_connect(DB_SERVER, DB_USER, DB_PASS, DB_DATABASE);
+
+    if (!$conn) {
+        throw new Exception('No se pudo establecer la conexión con la base de datos.');
+    }
+} catch (Throwable $e) {
+    error_log('[UNITY][DB_CONNECTION] ' . $e->getMessage());
+
     echo json_encode([
-        "codigo" => 400,
-        "mensaje" => "connection.php: Error intentando conectar",
-        "respuesta" => $e->getMessage()
+        'codigo' => 400,
+        'mensaje' => 'connection.php: Error intentando conectar',
+        'respuesta' => ''
     ]);
     exit;
 }

--- a/unity/constants.php
+++ b/unity/constants.php
@@ -75,7 +75,39 @@ define('UNITY_TYPE', [
 ]);
 
 // Datos de conexión a la BBDD
-$servidor_bd = $_SERVER['SERVER_NAME'] == 'localhost' ? 'localhost' : 'db5016239277.hosting-data.io';
-$usuario = $_SERVER['SERVER_NAME'] == 'localhost' ? 'root' : 'dbu2777657';
-$clave = $_SERVER['SERVER_NAME'] == 'localhost' ? '' : 'apdtmMdp27042304()';
-$bd = 'dbs13217995';
+$isLocalEnvironment = isset($_SERVER['SERVER_NAME']) && $_SERVER['SERVER_NAME'] === 'localhost';
+
+if (!function_exists('unity_getenv_or_default')) {
+    /**
+     * Obtener una variable de entorno o usar un valor por defecto.
+     */
+    function unity_getenv_or_default(string $key, $default)
+    {
+        $value = getenv($key);
+        if ($value === false || $value === '') {
+            if (isset($_ENV[$key]) && $_ENV[$key] !== '') {
+                return $_ENV[$key];
+            }
+
+            return $default;
+        }
+
+        return $value;
+    }
+}
+
+if (!defined('DB_SERVER')) {
+    define('DB_SERVER', unity_getenv_or_default('DB_SERVER', $isLocalEnvironment ? 'localhost' : 'db5016239277.hosting-data.io'));
+}
+
+if (!defined('DB_USER')) {
+    define('DB_USER', unity_getenv_or_default('DB_USER', $isLocalEnvironment ? 'root' : 'dbu2777657'));
+}
+
+if (!defined('DB_PASS')) {
+    define('DB_PASS', unity_getenv_or_default('DB_PASS', $isLocalEnvironment ? '' : 'apdtmMdp27042304()'));
+}
+
+if (!defined('DB_DATABASE')) {
+    define('DB_DATABASE', unity_getenv_or_default('DB_DATABASE', 'dbs13217995'));
+}


### PR DESCRIPTION
## Summary
- Define constantes de conexión a base de datos en unity/constants.php usando variables de entorno con valores por defecto seguros según el entorno
- Actualiza unity/connection.php para aprovechar las nuevas constantes y manejar los errores sin exponer detalles en la respuesta JSON mientras registra el fallo en logs

## Testing
- php -l unity/constants.php
- php -l unity/connection.php
- for file in unity/get_*.php; do php -l "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68d28d0115cc8325a5d1ee9d97ebc72e