### PR TITLE
Refactor admin header layout and styles

### DIFF
--- a/admin/change_password.php
+++ b/admin/change_password.php
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin - PraceAR - Cambiar Contraseña</title>
+    <link rel="stylesheet" href="./css/header.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <link rel='icon' href='./img/favicon.png' type='image/png'>
 

--- a/admin/components/languages.php
+++ b/admin/components/languages.php
@@ -1,68 +1,19 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Languages</title>
-    <style>
-        .flags {
-            display: flex;
-            list-style: none;
-            padding: 0;
-        }
-
-        .flags li {
-            margin-right: 10px;
-        }
-
-        .flags a {
-            text-decoration: none;
-            color: black;
-
-            img {
-                box-shadow: 0 0 2px 1px black;
-            }
-        }
-
-        @media screen and (max-width: 600px) {
-            .flags {
-                flex-direction: column;
-                align-items: flex-end;
-            }
-
-            .flags li {
-                margin-bottom: 5px;
-            }
-
-        }
-    </style>
-</head>
-
-<body>
-    <nav style="position: fixed; right: 1rem;top: 1rem">
-        <ul class="flags">
-            <?php
-            foreach (LANGUAGES as $key_language => $text_language):
-                ?>
-                <li>
-                    <?php
-                    $page = isset($_REQUEST['page']) ? "&page=" . $_REQUEST['page'] : '';
-                    $caseta = isset($_REQUEST['caseta']) ? "&caseta=" . $_REQUEST['caseta'] : '';
-                    $codigo_idioma = isset($_REQUEST['codigo_idioma']) ? "&codigo_idioma=" . $_REQUEST['codigo_idioma'] : '';
-                    $id = isset($_REQUEST['id']) ? "&id=" . $_REQUEST['id'] : '';
-                    ?>
-                    <a href="<?= "?lang=$key_language$caseta$page$id$codigo_idioma" ?>" aria-label="<?= $text_language ?>"
-                        tabindex="0">
-                        <img width="15" height="15" src="<?= FLAG_IMAGES_URL . "$key_language.png" ?>"
-                            alt="<?= $text_language ?>">
-                    </a>
-                </li>
+<nav class="language-selector" aria-label="Selector de idioma">
+    <ul class="flags">
+        <?php foreach (LANGUAGES as $key_language => $text_language): ?>
+            <li>
                 <?php
-            endforeach;
-            ?>
-        </ul>
-    </nav>
-</body>
-
-</html>
+                $page = isset($_REQUEST['page']) ? "&page=" . $_REQUEST['page'] : '';
+                $caseta = isset($_REQUEST['caseta']) ? "&caseta=" . $_REQUEST['caseta'] : '';
+                $codigo_idioma = isset($_REQUEST['codigo_idioma']) ? "&codigo_idioma=" . $_REQUEST['codigo_idioma'] : '';
+                $id = isset($_REQUEST['id']) ? "&id=" . $_REQUEST['id'] : '';
+                ?>
+                <a href="<?= "?lang=$key_language$caseta$page$id$codigo_idioma" ?>" aria-label="<?= $text_language ?>"
+                    tabindex="0">
+                    <img class="language-flag" width="15" height="15"
+                        src="<?= FLAG_IMAGES_URL . "$key_language.png" ?>" alt="<?= $text_language ?>">
+                </a>
+            </li>
+        <?php endforeach; ?>
+    </ul>
+</nav>

--- a/admin/components/main_menu.php
+++ b/admin/components/main_menu.php
@@ -1,113 +1,18 @@
-<!DOCTYPE html>
-<html lang="es">
+<nav class="main-nav" role="navigation" aria-label="Menú principal">
+    <a href="./?lang=<?= $_REQUEST['lang'] ?? 'gl' ?>" class="nav-link" aria-label="Ir a Inicio">Inicio</a>
+    <a href="./?page=ships&lang=<?= $_REQUEST['lang'] ?? 'gl' ?>" class="nav-link" aria-label="Ir a Naves">Naves</a>
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Menú Principal</title>
-    <style>
-        .nav-link {
-            text-decoration: none;
-            color: inherit;
-            position: relative;
-        }
-
-        .nav-link::after {
-            content: '';
-            position: absolute;
-            width: 100%;
-            height: 2px;
-            bottom: -2px;
-            left: 0;
-            background-color: currentColor;
-            visibility: hidden;
-            transform: scaleX(0);
-            transition: all 0.3s ease-in-out;
-        }
-
-        .nav-link:hover::after {
-            visibility: visible;
-            transform: scaleX(1);
-        }
-
-        .dropdown {
-            position: relative;
-            display: inline-block;
-        }
-
-        .dropdown-content {
-            display: none;
-            position: absolute;
-            background-color: white;
-            min-width: 200px;
-            box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.2);
-            z-index: 1;
-        }
-
-        .dropdown-content a {
-            display: block;
-            padding: 10px;
-            text-align: left;
-            color: #1e7dbd;
-            text-decoration: none;
-        }
-
-        .dropdown-content a:hover {
-            background-color: #f1f1f1;
-        }
-
-        .dropdown:hover .dropdown-content {
-            display: block;
-        }
-
-        .enlace_cierre_sesion img {
-            width: 24px;
-            height: 24px;
-        }
-
-        .texto-azul {
-            color: blue;
-        }
-
-        @media screen and (max-width: 600px) {
-            .nav-link {
-                font-size: 0.9em;
-            }
-
-            .dropdown-content {
-                min-width: 150px;
-            }
-
-            .enlace_cierre_sesion img {
-                width: 20px;
-                height: 20px;
-            }
-        }
-    </style>
-</head>
-
-<body>
-    <nav style="text-align: center; max-width: 1100px; justify-content: center; margin: 0 auto; padding: 10px 0; display: flex; gap: 10px; flex-wrap: wrap; font-size: 1.15em; color: #1e7dbd; font-weight: bold;"
-        role="navigation" aria-label="Menú principal">
-        <a href="./?lang=<?= $_REQUEST['lang'] ?? 'gl' ?>" class="nav-link"
-            style="text-align: center; margin-right: 10px;" aria-label="Ir a Inicio">Inicio</a>
-        <a href="./?page=ships&lang=<?= $_REQUEST['lang'] ?? 'gl' ?>" class="nav-link"
-            style="text-align: center; margin-right: 10px;" aria-label="Ir a Naves">Naves</a>
-
-        <div class="dropdown" role="menu" aria-label="Opciones de contraseña">
-            <a href="./?page=change_password&lang=<?= $_REQUEST['lang'] ?? 'gl' ?>" class="nav-link"
-                aria-haspopup="true" aria-expanded="false">Cambiar contraseña</a>
-            <div class="dropdown-content" role="menu">
-                <a href="./?page=password_generator&lang=<?= $_REQUEST['lang'] ?? 'gl' ?>" class="nav-link"
-                    role="menuitem" aria-label="Ir a Generador de contraseñas">Generador de contraseñas</a>
-            </div>
+    <div class="dropdown" role="menu" aria-label="Opciones de contraseña">
+        <a href="./?page=change_password&lang=<?= $_REQUEST['lang'] ?? 'gl' ?>" class="nav-link"
+            aria-haspopup="true" aria-expanded="false">Cambiar contraseña</a>
+        <div class="dropdown-content" role="menu">
+            <a href="./?page=password_generator&lang=<?= $_REQUEST['lang'] ?? 'gl' ?>" class="nav-link"
+                role="menuitem" aria-label="Ir a Generador de contraseñas">Generador de contraseñas</a>
         </div>
+    </div>
 
-        <a href="./?page=logout&lang=<?= $_REQUEST['lang'] ?? 'gl' ?>" class="nav-link enlace_cierre_sesion"
-            style="text-align: center; margin-right: 10px;" aria-label="Cerrar sesión">
-            <img src="./img/logout_icon.png" alt="Cerrar sesión" title="Cerrar sesión">
-        </a>
-    </nav>
-</body>
-
-</html>
+    <a href="./?page=logout&lang=<?= $_REQUEST['lang'] ?? 'gl' ?>" class="nav-link enlace_cierre_sesion"
+        aria-label="Cerrar sesión">
+        <img src="./img/logout_icon.png" alt="Cerrar sesión" title="Cerrar sesión">
+    </a>
+</nav>

--- a/admin/components/sections/header.php
+++ b/admin/components/sections/header.php
@@ -1,70 +1,18 @@
 <?php
 require_once(HELPERS . 'get_language.php');
 ?>
-<!DOCTYPE html>
-<html lang="es">
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Página de administración</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
-    <link rel='icon' href='./img/favicon.png' type='image/png'>
-
-    <!-- Iconos para dispositivos Apple -->
-    <link rel="apple-touch-icon" sizes="180x180" href="./img/apple-touch-icon-180x180.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="./img/apple-touch-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="./img/apple-touch-icon-120x120.png">
-
-    <!-- Icono para Android (PWA) -->
-    <link rel="icon" sizes="192x192" href="icon-192x192.png">
-
-    <!-- Manifesto Web (PWA) -->
-    <link rel="manifest" href="/manifest.json">
-
-    <style>
-        #cabecera_pagina_edicion {
-            font-size: 2.5rem;
-            margin: 0;
-            padding: 10px;
-        }
-
-        #cabecera-menu-navegacion {
-            height: 175px;
-            display: flex;
-            justify-content: space-around;
-            align-items: center;
-        }
-
-        @media screen and (max-width: 600px) {
-            #cabecera_pagina_edicion {
-                font-size: 1.5rem;
-            }
-
-        }
-    </style>
-</head>
-
-<body class="container">
-    <header style="display:flex; flex-direction: column; align-items: center; gap: 20px;">
-        <div style="display:flex; justify-content: space-around; width: 100%;">
-            <h1 id="cabecera_pagina_edicion" tabindex="0">Admin: PraceAR
-                <strong style="font-size: 0.95rem">Idioma actual:
-                    <img style="box-shadow: 0 0 2px 1px black;" width="15" height="15"
-                        src="<?= FLAG_IMAGES_URL . (get_language()) . ".png" ?>" alt="<?= get_language() ?>"
-                        tabindex="0">
-                </strong>
-            </h1>
-            <?php
-            require_once(COMPONENT_ADMIN . "languages.php");
-            ?>
-        </div>
-        <nav id="cabecera-menu-navegacion" style="width: 100%;">
-            <?php
-            require_once(COMPONENT_ADMIN . "main_menu.php");
-            ?>
-        </nav>
-    </header>
-</body>
-
-</html>
+<header class="admin-header" role="banner">
+    <div class="admin-header__top">
+        <h1 id="cabecera_pagina_edicion" tabindex="0">Admin: PraceAR
+            <strong class="admin-header__language">Idioma actual:
+                <img class="language-flag current-language-flag" width="15" height="15"
+                    src="<?= FLAG_IMAGES_URL . (get_language()) . ".png" ?>" alt="<?= get_language() ?>" tabindex="0">
+            </strong>
+        </h1>
+        <?php require_once(COMPONENT_ADMIN . "languages.php"); ?>
+    </div>
+    <div id="cabecera-menu-navegacion" class="admin-header__menu">
+        <?php require_once(COMPONENT_ADMIN . "main_menu.php"); ?>
+    </div>
+</header>

--- a/admin/css/header.css
+++ b/admin/css/header.css
@@ -1,0 +1,181 @@
+.admin-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+}
+
+.admin-header__top {
+    display: flex;
+    justify-content: space-around;
+    width: 100%;
+    align-items: center;
+}
+
+.admin-header__language {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.95rem;
+}
+
+.language-flag {
+    box-shadow: 0 0 2px 1px black;
+    width: 15px;
+    height: 15px;
+}
+
+.current-language-flag {
+    border-radius: 2px;
+}
+
+#cabecera_pagina_edicion {
+    font-size: 2.5rem;
+    margin: 0;
+    padding: 10px;
+}
+
+#cabecera-menu-navegacion {
+    width: 100%;
+    height: 175px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.language-selector {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+}
+
+.language-selector .flags {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.language-selector .flags li {
+    margin-right: 10px;
+}
+
+.language-selector .flags li:last-child {
+    margin-right: 0;
+}
+
+.language-selector .flags a {
+    text-decoration: none;
+    color: inherit;
+}
+
+.main-nav {
+    text-align: center;
+    max-width: 1100px;
+    justify-content: center;
+    margin: 0 auto;
+    padding: 10px 0;
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    font-size: 1.15em;
+    color: #1e7dbd;
+    font-weight: bold;
+}
+
+.main-nav .nav-link {
+    text-decoration: none;
+    color: inherit;
+    position: relative;
+}
+
+.main-nav .nav-link::after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 2px;
+    bottom: -2px;
+    left: 0;
+    background-color: currentColor;
+    visibility: hidden;
+    transform: scaleX(0);
+    transition: all 0.3s ease-in-out;
+}
+
+.main-nav .nav-link:hover::after,
+.main-nav .nav-link:focus-visible::after {
+    visibility: visible;
+    transform: scaleX(1);
+}
+
+.dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: white;
+    min-width: 200px;
+    box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.2);
+    z-index: 1;
+}
+
+.dropdown-content a {
+    display: block;
+    padding: 10px;
+    text-align: left;
+    color: #1e7dbd;
+    text-decoration: none;
+}
+
+.dropdown-content a:hover,
+.dropdown-content a:focus-visible {
+    background-color: #f1f1f1;
+}
+
+.dropdown:hover .dropdown-content,
+.dropdown:focus-within .dropdown-content {
+    display: block;
+}
+
+.enlace_cierre_sesion img {
+    width: 24px;
+    height: 24px;
+}
+
+@media screen and (max-width: 600px) {
+    #cabecera_pagina_edicion {
+        font-size: 1.5rem;
+    }
+
+    .admin-header__top {
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .language-selector {
+        position: static;
+        align-self: flex-end;
+    }
+
+    .language-selector .flags {
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 5px;
+    }
+
+    .main-nav {
+        font-size: 0.95em;
+    }
+
+    .dropdown-content {
+        min-width: 150px;
+    }
+
+    .enlace_cierre_sesion img {
+        width: 20px;
+        height: 20px;
+    }
+}

--- a/admin/edit.php
+++ b/admin/edit.php
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin - PraceAR - Editar Datos Generales de Puesto - Página de administración</title>
+    <link rel="stylesheet" href="./css/header.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <link rel='icon' href='./img/favicon.png' type='image/png'>
 

--- a/admin/edit_translations.php
+++ b/admin/edit_translations.php
@@ -6,6 +6,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin - PraceAR - Editar Traducciones de Puesto - Página de administración</title>
+    <link rel="stylesheet" href="./css/header.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <link rel='icon' href='./img/favicon.png' type='image/png'>
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin - PraceAR - Página Principal del Panel de Administración</title>
+    <link rel="stylesheet" href="./css/header.css">
     <?php require_once(CSS_ADMIN . 'index_admin.php'); ?>
     <link rel='icon' href='./img/favicon.png' type='image/png'>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/admin/password_generator.php
+++ b/admin/password_generator.php
@@ -177,6 +177,7 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin - PraceAR - Generador de Contraseñas</title>
+    <link rel="stylesheet" href="./css/header.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <link rel="icon" href="./img/favicon.png" type="image/png">
     <style>
@@ -192,9 +193,7 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
 </head>
 
 <body>
-    <header role="banner" aria-label="Encabezado principal">
-        <?php require_once COMPONENT_ADMIN . 'sections' . DIRECTORY_SEPARATOR . 'header.php'; ?>
-    </header>
+    <?php require_once COMPONENT_ADMIN . 'sections' . DIRECTORY_SEPARATOR . 'header.php'; ?>
 
     <h1 style="text-align: center;" tabindex="0">Generador de Contraseñas</h1>
 

--- a/admin/ships.php
+++ b/admin/ships.php
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin - PraceAR - Mapas de las Ameas, Naves y Murallones</title>
+    <link rel="stylesheet" href="./css/header.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <link rel='icon' href='./img/favicon.png' type='image/png'>
 
@@ -31,15 +32,11 @@
             border: none;
         }
     </style>
+    <?php require_once(CSS_ADMIN . 'ships_admin.php'); ?>
 </head>
 
 <body>
-    <header>
-        <?php
-        require_once(COMPONENT_ADMIN . 'sections' . DIRECTORY_SEPARATOR . 'header.php');
-        require_once(CSS_ADMIN . 'ships_admin.php');
-        ?>
-    </header>
+    <?php require_once(COMPONENT_ADMIN . 'sections' . DIRECTORY_SEPARATOR . 'header.php'); ?>
 
     <main class="maps">
         <h2>Mapas de las Ameas, Naves y Murallones</h2>

--- a/login.php
+++ b/login.php
@@ -163,6 +163,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin - PraceAR - Formulario de Inicio de Sesión</title>
+    <link rel="stylesheet" href="./admin/css/header.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <link rel='icon' href='./img/favicon.png' type='image/png'>
 


### PR DESCRIPTION
## Summary
- simplify the admin header, language selector, and main menu components to output reusable fragments without standalone HTML wrappers
- consolidate their inline styles into a shared `admin/css/header.css`
- link the shared stylesheet from the admin views (including ships and password pages) so the header renders within the existing `<body>` markup

## Testing
- for file in admin/components/sections/header.php admin/components/languages.php admin/components/main_menu.php admin/index.php admin/edit.php admin/ships.php admin/change_password.php admin/edit_translations.php admin/password_generator.php login.php; do php -l "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68d28ce88b08832580e9f25563903a13