### PR TITLE
Remove captcha from admin forms

### DIFF
--- a/admin/change_password.php
+++ b/admin/change_password.php
@@ -44,9 +44,6 @@
     require_once COMPONENT_ADMIN . 'sections' . DIRECTORY_SEPARATOR . 'header.php';
     require_once HELPERS . 'clean_input.php';
     require_once HELPERS . 'verify_strong_password.php';
-    require_once HELPERS . 'captcha.php';
-
-    $captcha_key = 'change_password_form';
 
     $pepper_config = include 'pepper2.php';  // Incluimos la configuración del pepper.
     
@@ -97,10 +94,6 @@
         }
 
         try {
-            if (!captcha_validate($captcha_key, $_POST['captcha_answer'] ?? null)) {
-                throw new Exception("La verificación captcha no es correcta.");
-            }
-
             $user_id = $_SESSION['id'];
             $old_password = trim($_POST['old_password']);
             $new_password = trim($_POST['new_password']);
@@ -274,7 +267,6 @@
         }
     }
 
-    $captcha_question = captcha_get_question($captcha_key);
     ?>
 
     <h1 style="text-align: center;">Cambiar contraseña</h1>
@@ -325,16 +317,6 @@
                 <li>Sin secuencias alfabéticas inseguras como abc, cba, ni en horizontal como qwe</li>
                 <li>Sin secuencias de caracteres especiales inseguras como ()</li>
             </ul>
-        </div>
-        <div id="form-group">
-            <label for="captcha" class="required" aria-hidden="false">Verificación humana: <span style="color: red;"
-                    aria-hidden="true">*</span></label>
-            <p id="captcha-question" style="margin-bottom: .5rem;">
-                <?= htmlspecialchars($captcha_question) ?>
-            </p>
-            <input type="text" name="captcha_answer" id="captcha" required aria-required="true"
-                aria-describedby="captcha-help" inputmode="numeric" pattern="[0-9]+">
-            <p id="captcha-help" class="sr-only">Responda con el resultado numérico de la pregunta para continuar.</p>
         </div>
         <div id="form-group">
             <input type="submit" value="Cambiar contraseña" aria-label="Cambiar contraseña">

--- a/admin/edit.php
+++ b/admin/edit.php
@@ -59,7 +59,6 @@
         die('<h2 style="text-align: center;">Error al obtener los datos del puesto. <a href="index.php">Volver</a></h2>');
     }
 
-    $captcha_question = captcha_get_question('edit_stall_form');
     ?>
 
     <form id="formulario-editar" action="#" method="post" enctype="multipart/form-data"
@@ -162,15 +161,6 @@
             <input name="caseta_padre" type="text" id="caseta-padre"
                 value="<?= htmlspecialchars($fila["caseta_padre"]) ?>" placeholder="Código de caseta padre"
                 aria-label="Caseta padre">
-        </div>
-        <div>
-            <label for="captcha" class="required">Verificación humana <span style="color: red;">*</span></label>
-            <span id="captcha-question" style="display: block; margin-bottom: .5rem; font-weight: 600;">
-                <?= htmlspecialchars($captcha_question) ?>
-            </span>
-            <input type="text" id="captcha" name="captcha_answer" required aria-required="true"
-                aria-describedby="captcha-help" inputmode="numeric" pattern="[0-9]+">
-            <span id="captcha-help" class="visually-hidden">Responda con el resultado numérico de la pregunta.</span>
         </div>
         <div id="div-botones">
             <input id="actualizar" type="submit" value="Actualizar" aria-label="Actualizar datos del puesto">

--- a/admin/edit_translations.php
+++ b/admin/edit_translations.php
@@ -80,8 +80,6 @@
 
     $puesto_encontrado = true;
 
-    $captcha_question = captcha_get_question('edit_translations_form');
-
     ?>
 
     <h2 style="text-align: center;">Traducción del puesto<span style="color: #1e7dbd;">
@@ -122,13 +120,6 @@
             caracteres.</span>
 
         <input type="hidden" name="id_traduccion" value="<?= htmlspecialchars($data['id'] ?? "") ?>">
-        <label for="captcha" class="required">Verificación humana <span style="color: red;">*</span></label>
-        <span id="captcha-question" style="display: block; margin-bottom: .5rem; font-weight: 600;">
-            <?= htmlspecialchars($captcha_question) ?>
-        </span>
-        <input type="text" id="captcha" name="captcha_answer" required aria-required="true"
-            aria-describedby="captcha-help" inputmode="numeric" pattern="[0-9]+">
-        <span id="captcha-help" class="visually-hidden">Responda con el resultado numérico de la pregunta.</span>
         <input type="submit" value="Actualizar">
     </form>
     <p style="color: red; text-align: center;">Los campos marcados con <span style="color: red;"

--- a/admin/index.php
+++ b/admin/index.php
@@ -22,26 +22,16 @@
     require_once(SECTIONS . 'header.php');
     require_once(HELPERS . 'truncate_text.php');
     require_once(HELPERS . 'clean_input.php');
-    require_once(HELPERS . 'captcha.php');
     ?>
 
     <?php
-    $captcha_key = 'admin_search_form';
-    $captcha_error = '';
-    $captcha_valid = true;
+    if (!isset($_SESSION['csrf'])) {
+        $_SESSION['csrf'] = bin2hex(random_bytes(32)); // Generar un nuevo token CSRF
+    }
 
     if ($_SERVER["REQUEST_METHOD"] === "POST") {
-        if (!isset($_SESSION['csrf'])) {
-            $_SESSION['csrf'] = bin2hex(random_bytes(32)); // Generar un nuevo token CSRF
-        }
-
         if (!isset($_POST['csrf']) || !hash_equals($_SESSION['csrf'], $_POST['csrf'])) {
             die("Petición no válida");
-        }
-
-        if (!captcha_validate($captcha_key, $_POST['captcha_answer'] ?? null)) {
-            $captcha_valid = false;
-            $captcha_error = '<span style="color: red;">La verificación captcha no es correcta.</span>';
         }
     }
 
@@ -59,7 +49,7 @@
     $caseta = '';
 
     // Manejo de búsqueda por caseta
-    if ($_SERVER["REQUEST_METHOD"] === "POST" && $captcha_valid && isset($_POST['caseta'])) {
+    if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST['caseta'])) {
         $caseta = limpiar_input($_POST['caseta']);
         // Redirigir usando GET para mantener la búsqueda en la URL
         $params = [
@@ -69,15 +59,10 @@
         ];
         header("Location: ?" . http_build_query($params));
         exit;
-    } elseif ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST['caseta'])) {
-        $caseta = limpiar_input($_POST['caseta']);
-        $busqueda_hecha = true;
     } elseif (isset($_GET['caseta'])) {
         // Si hay parámetro GET 'caseta', lo limpiamos
         $caseta = limpiar_input($_GET['caseta']);
     }
-
-    $captcha_question = captcha_get_question($captcha_key);
 
     $sql_total = "SELECT COUNT(p.id) as total FROM puestos p 
                       RIGHT JOIN puestos_traducciones pt ON p.id = pt.puesto_id
@@ -139,27 +124,12 @@
                                 placeholder="Código de caseta. P. ej. CE001, CO121, MC001, NA338, NC041" name="caseta"
                                 <?php if (!$busqueda_hecha) echo 'autofocus'; ?>>
                             <input type="hidden" name="lang" id="lang" value="<?= htmlspecialchars(get_language()) ?>">
-                            <div class="captcha-wrapper" style="margin: .5rem 0; display: grid; gap: .5rem;">
-                                <label for="captcha" class="required" style="margin-bottom: 0;">Verificación humana:
-                                    <span aria-hidden="true">*</span></label>
-                                <span id="captcha-question" style="font-weight: 600;">
-                                    <?= htmlspecialchars($captcha_question) ?>
-                                </span>
-                                <input type="text" id="captcha" name="captcha_answer" required aria-required="true"
-                                    aria-describedby="captcha-help" inputmode="numeric" pattern="[0-9]+">
-                                <small id="captcha-help">Responda con el resultado numérico de la pregunta.</small>
-                            </div>
                             <input type="submit" value="Buscar">
                             <input id="input-reseteo" name="input_reseteo" type="reset" value="Reiniciar">
                             <input id="input-deshacer-busqueda" type="button" value="Deshacer"
                                 onclick="window.location.href='?lang=<?= htmlspecialchars(get_language()) ?>'">
                             <input type="hidden" name="csrf" id="csrf" value="<?= htmlspecialchars($_SESSION['csrf']) ?>">
                         </form>
-                        <?php if ($captcha_error !== ''): ?>
-                            <div role="alert" aria-live="polite" style="margin-top: .5rem; text-align: left;">
-                                <?= $captcha_error ?>
-                            </div>
-                        <?php endif; ?>
                     </search>
                     <?php require_once(SECTIONS . 'pagination.php'); ?>
                 </caption>

--- a/admin/password_generator.php
+++ b/admin/password_generator.php
@@ -4,10 +4,8 @@
 
 require_once HELPERS . 'clean_input.php';
 require_once CONNECTION;
-require_once HELPERS . 'captcha.php';
 
 $app_id_config = require_once HELPERS . 'verify_strong_password.php';
-$captcha_key = 'password_generator_form';
 $pepper_config = include 'pepper2.php';
 
 $today = date('Y-m-d');
@@ -115,13 +113,9 @@ $mostrar_boton = false;
 $length = 16;
 $quantity = 1; // Fijar la cantidad de contraseñas a 1
 
-$captcha_question = '';
-
 if ($_SERVER['REQUEST_METHOD'] === "POST") {
     if (isset($_POST['csrf']) && hash_equals($_SESSION['csrf'], $_POST['csrf'])) {
-        if (!captcha_validate($captcha_key, $_POST['captcha_answer'] ?? null)) {
-            $result = '<span style="color: red; text-align: center;">La verificación captcha no es correcta.</span>';
-        } elseif (isset($_POST['length'])) { // Eliminar referencia a 'quantity'
+        if (isset($_POST['length'])) { // Eliminar referencia a 'quantity'
             $length = limpiar_input($_POST['length']);
             $length_range = limpiar_input($_POST['length_range']);
 
@@ -174,8 +168,6 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
         }
     }
 }
-
-$captcha_question = captcha_get_question($captcha_key);
 ?>
 
 <!DOCTYPE html>
@@ -228,16 +220,6 @@ $captcha_question = captcha_get_question($captcha_key);
         <output id="length-output" style="display: block; text-align: center; margin-top: -1.5rem;" aria-live="polite">
             <?= htmlspecialchars($length, ENT_QUOTES, 'UTF-8') ?>
         </output>
-
-        <label for="captcha" class="required" aria-hidden="false">Verificación humana:
-            <span aria-hidden="true">*</span>
-        </label>
-        <p id="captcha-question" style="margin-bottom: .5rem;">
-            <?= htmlspecialchars($captcha_question) ?>
-        </p>
-        <input type="text" id="captcha" name="captcha_answer" required aria-required="true"
-            aria-describedby="captcha-help" inputmode="numeric" pattern="[0-9]+">
-        <p id="captcha-help" class="sr-only">Responda con el resultado numérico de la pregunta para generar la contraseña.</p>
 
         <input type="submit" value="Generar Contraseña" aria-label="Generar contraseña">
     </form>

--- a/helpers/update_stalls.php
+++ b/helpers/update_stalls.php
@@ -4,7 +4,6 @@ require_once HELPERS . "get_language.php";
 require_once HELPERS . "save_image.php";
 require_once HELPERS . "delete_image.php";
 require_once HELPERS . "verify_malicious_photo.php";
-require_once HELPERS . "captcha.php";
 
 $mensaje = '';
 
@@ -12,11 +11,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     global $conexion;
     if (!isset($_SESSION['csrf']) || !hash_equals($_SESSION['csrf'], $_POST['csrf'])) {
         throw new Exception("Token CSRF inválido.");
-    }
-
-    if (!captcha_validate('edit_stall_form', $_POST['captcha_answer'] ?? null)) {
-        $mensaje = "<span style='color: red;'>La verificación captcha no es correcta.</span>";
-        return;
     }
 
     $stall_id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);

--- a/helpers/update_stalls_translations.php
+++ b/helpers/update_stalls_translations.php
@@ -1,16 +1,10 @@
 <?php
 require_once HELPERS . "clean_input.php";
-require_once HELPERS . "captcha.php";
 
 $mensaje = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!isset($_SESSION['csrf']) || !hash_equals($_SESSION['csrf'], $_POST['csrf'])) {
         throw new Exception("Token CSRF inválido.");
-    }
-
-    if (!captcha_validate('edit_translations_form', $_POST['captcha_answer'] ?? null)) {
-        $mensaje = "<span style='color: red;'>La verificación captcha no es correcta.</span>";
-        return;
     }
 
     extract($_REQUEST);


### PR DESCRIPTION
## Summary
- Remove captcha requirements from admin search, password change, edit, and translation forms, leaving CSRF validation in place.
- Simplify admin helpers by deleting unused captcha validation calls.

## Testing
- php -l admin/change_password.php
- php -l admin/edit.php
- php -l admin/edit_translations.php
- php -l admin/index.php
- php -l admin/password_generator.php
- php -l helpers/update_stalls.php
- php -l helpers/update_stalls_translations.php

------
https://chatgpt.com/codex/tasks/task_e_68d39ead52c48325b2a7fa8ab50cc152