### PR TITLE
feat: migrate admin scripts to typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ admin/js/helpers/api_key.js
 wolfram_alpha_app_id.php
 .env
 assets/
+
+node_modules/

--- a/admin/ts/change_password.ts
+++ b/admin/ts/change_password.ts
@@ -1,90 +1,119 @@
-import { tieneSecuenciasAlfabeticasInseguras, tieneSecuenciasDeCaracteresEspecialesInseguras, tieneSecuenciasNumericasInseguras, } from "../../js/helpers/verify_strong_password.js";
-function getPasswordInput(id) {
+import {
+    tieneSecuenciasAlfabeticasInseguras,
+    tieneSecuenciasDeCaracteresEspecialesInseguras,
+    tieneSecuenciasNumericasInseguras,
+} from "../../js/helpers/verify_strong_password.js";
+
+function getPasswordInput(id: string): HTMLInputElement {
     const element = document.getElementById(id);
+
     if (!(element instanceof HTMLInputElement)) {
         throw new Error(`No se encontró el campo de contraseña con id "${id}".`);
     }
+
     return element;
 }
+
 const formulario = document.getElementById("formulario-cambio-contrasena");
+
 if (!(formulario instanceof HTMLFormElement)) {
     throw new Error("No se encontró el formulario de cambio de contraseña.");
 }
+
 const campoContrasenaActual = getPasswordInput("old-password");
 const campoNuevaContrasena = getPasswordInput("new-password");
 const campoConfirmacion = getPasswordInput("confirm-password");
-formulario.addEventListener("submit", (event) => {
+
+formulario.addEventListener("submit", (event: SubmitEvent) => {
     const contrasenaActual = campoContrasenaActual.value.trim();
     const contrasenaActualOriginal = campoContrasenaActual.value;
     const nuevaContrasena = campoNuevaContrasena.value.trim();
     const nuevaContrasenaOriginal = campoNuevaContrasena.value;
     const confirmacion = campoConfirmacion.value.trim();
     const confirmacionOriginal = campoConfirmacion.value;
-    if (typeof contrasenaActual !== "string"
+
+    if (
+        typeof contrasenaActual !== "string"
         || typeof nuevaContrasena !== "string"
-        || typeof confirmacion !== "string") {
+        || typeof confirmacion !== "string"
+    ) {
         event.preventDefault();
         alert("Error en los datos introducidos.");
         return;
     }
-    if (contrasenaActualOriginal !== contrasenaActual
+
+    if (
+        contrasenaActualOriginal !== contrasenaActual
         || nuevaContrasenaOriginal !== nuevaContrasena
-        || confirmacionOriginal !== confirmacion) {
+        || confirmacionOriginal !== confirmacion
+    ) {
         event.preventDefault();
         alert("Las contraseñas no pueden tener espacios al inicio o al final.");
         return;
     }
+
     if (!contrasenaActual || !nuevaContrasena || !confirmacion) {
         event.preventDefault();
         alert("Todos los campos son obligatorios.");
         return;
     }
+
     if (nuevaContrasena !== confirmacion) {
         event.preventDefault();
         alert("Las contraseñas no coinciden.");
         return;
     }
-    const longitudInvalida = (valor) => valor.length < 16 || valor.length > 1024;
-    if (longitudInvalida(contrasenaActual)
+
+    const longitudInvalida = (valor: string) => valor.length < 16 || valor.length > 1024;
+
+    if (
+        longitudInvalida(contrasenaActual)
         || longitudInvalida(nuevaContrasena)
-        || longitudInvalida(confirmacion)) {
+        || longitudInvalida(confirmacion)
+    ) {
         event.preventDefault();
         alert("Las contraseñas deben tener entre 16 y 1024 caracteres.");
         return;
     }
+
     let numeroCaracteresEspeciales = 0;
     let numeroMayusculas = 0;
     let numeroMinusculas = 0;
     let numeroNumeros = 0;
+
     const regexCaracteresEspeciales = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]+/;
     const regexMayusculas = /[A-Z]/;
     const regexMinusculas = /[a-z]/;
     const regexNumeros = /[0-9]/;
+
     for (const caracter of nuevaContrasena) {
         if (regexCaracteresEspeciales.test(caracter)) {
             numeroCaracteresEspeciales += 1;
-        }
-        else if (regexMayusculas.test(caracter)) {
+        } else if (regexMayusculas.test(caracter)) {
             numeroMayusculas += 1;
-        }
-        else if (regexMinusculas.test(caracter)) {
+        } else if (regexMinusculas.test(caracter)) {
             numeroMinusculas += 1;
-        }
-        else if (regexNumeros.test(caracter)) {
+        } else if (regexNumeros.test(caracter)) {
             numeroNumeros += 1;
         }
     }
-    if (numeroMayusculas < 1
+
+    if (
+        numeroMayusculas < 1
         || numeroMinusculas < 1
         || numeroNumeros < 1
-        || numeroCaracteresEspeciales < 3) {
+        || numeroCaracteresEspeciales < 3
+    ) {
         event.preventDefault();
         alert("La nueva contraseña debe tener al menos una letra mayúscula, una letra minúscula, un número y tres caracteres especiales distintos.");
         return;
     }
-    if (tieneSecuenciasAlfabeticasInseguras(nuevaContrasena)
+
+    if (
+        tieneSecuenciasAlfabeticasInseguras(nuevaContrasena)
         || tieneSecuenciasDeCaracteresEspecialesInseguras(nuevaContrasena)
-        || tieneSecuenciasNumericasInseguras(nuevaContrasena)) {
+        || tieneSecuenciasNumericasInseguras(nuevaContrasena)
+    ) {
         event.preventDefault();
         alert("La nueva contraseña no puede contener secuencias alfabéticas, de caracteres especiales o numéricas inseguras como \"abc\", \"qwerty\", \"qaz\", \"123\", \"147\", \"159\"");
     }

--- a/admin/ts/check_password_requirements.ts
+++ b/admin/ts/check_password_requirements.ts
@@ -1,71 +1,121 @@
-import { verifyStrongPassword, haSidoFiltradaEnBrechas, contrasenhaSimilarAUsuario, tieneSecuenciasNumericasInseguras, tieneSecuenciasAlfabeticasInseguras, tieneSecuenciasDeCaracteresEspecialesInseguras, tieneEspaciosAlPrincipioOAlFinal, } from "../../js/helpers/verify_strong_password.js";
-function getForm() {
+import {
+    verifyStrongPassword,
+    haSidoFiltradaEnBrechas,
+    contrasenhaSimilarAUsuario,
+    tieneSecuenciasNumericasInseguras,
+    tieneSecuenciasAlfabeticasInseguras,
+    tieneSecuenciasDeCaracteresEspecialesInseguras,
+    tieneEspaciosAlPrincipioOAlFinal,
+} from "../../js/helpers/verify_strong_password.js";
+
+declare global {
+    interface Window {
+        checkPasswordRequirements: () => Promise<void>;
+    }
+}
+
+function getForm(): HTMLFormElement {
     const form = document.getElementById("formulario-cambio-contrasena");
+
     if (!(form instanceof HTMLFormElement)) {
         throw new Error("No se encontró el formulario de cambio de contraseña.");
     }
+
     return form;
 }
-function getNewPasswordInput() {
+
+function getNewPasswordInput(): HTMLInputElement {
     const input = document.getElementById("new-password");
+
     if (!(input instanceof HTMLInputElement)) {
         throw new Error("No se encontró el campo de nueva contraseña.");
     }
+
     return input;
 }
-function getUsernameInput() {
+
+function getUsernameInput(): HTMLInputElement {
     const input = document.getElementById("nombre-usuario");
+
     if (!(input instanceof HTMLInputElement)) {
         throw new Error("No se encontró el campo de nombre de usuario.");
     }
+
     return input;
 }
+
 document.addEventListener("DOMContentLoaded", () => {
     const formulario = getForm();
     const inputNuevaContrasena = getNewPasswordInput();
     const inputNombreUsuario = getUsernameInput();
-    function crearMensajeError(texto) {
+
+    function crearMensajeError(texto: string): void {
         const spanError = document.createElement("span");
         spanError.style.color = "red";
         spanError.textContent = texto;
         inputNuevaContrasena.insertAdjacentElement("afterend", spanError);
     }
-    function bloquearEnvio() {
-        formulario.addEventListener("submit", (event) => {
-            event.preventDefault();
-        }, { once: true });
+
+    function bloquearEnvio(): void {
+        formulario.addEventListener(
+            "submit",
+            (event: SubmitEvent) => {
+                event.preventDefault();
+            },
+            { once: true },
+        );
     }
+
     window.checkPasswordRequirements = async () => {
         const nuevaContrasena = inputNuevaContrasena.value;
-        const mensajesError = formulario.querySelectorAll('span[style="color: red;"]');
+        const mensajesError = formulario.querySelectorAll<HTMLSpanElement>('span[style="color: red;"]');
         mensajesError.forEach((mensaje) => mensaje.remove());
+
         if (!verifyStrongPassword(nuevaContrasena)) {
-            crearMensajeError("La nueva contraseña no cumple con los requisitos de seguridad. Debe tener al menos 16 caracteres, una letra mayúscula, una letra minúscula, un número y tres caracteres especiales distintos.");
+            crearMensajeError(
+                "La nueva contraseña no cumple con los requisitos de seguridad. Debe tener al menos 16 caracteres, una letra mayúscula, una letra minúscula, un número y tres caracteres especiales distintos.",
+            );
             bloquearEnvio();
         }
+
         if (tieneEspaciosAlPrincipioOAlFinal(nuevaContrasena)) {
             crearMensajeError("La nueva contraseña no puede tener espacios al principio o al final.");
             bloquearEnvio();
         }
+
         if (tieneSecuenciasAlfabeticasInseguras(nuevaContrasena)) {
-            crearMensajeError("La nueva contraseña no puede contener secuencias alfabéticas inseguras como abc, cba, ni en vertical como qwe");
+            crearMensajeError(
+                "La nueva contraseña no puede contener secuencias alfabéticas inseguras como abc, cba, ni en vertical como qwe",
+            );
             bloquearEnvio();
         }
+
         if (tieneSecuenciasNumericasInseguras(nuevaContrasena)) {
-            crearMensajeError("La nueva contraseña no puede tener secuencias numéricas inseguras como 123, 987, ni en vertical como 147, ni en diagonal como 159 y 753");
+            crearMensajeError(
+                "La nueva contraseña no puede tener secuencias numéricas inseguras como 123, 987, ni en vertical como 147, ni en diagonal como 159 y 753",
+            );
             bloquearEnvio();
         }
+
         if (tieneSecuenciasDeCaracteresEspecialesInseguras(nuevaContrasena)) {
-            crearMensajeError("La nueva contraseña no puede contener secuencias de caracteres especiales inseguras como ()");
+            crearMensajeError(
+                "La nueva contraseña no puede contener secuencias de caracteres especiales inseguras como ()",
+            );
             bloquearEnvio();
         }
+
         if (contrasenhaSimilarAUsuario(nuevaContrasena, inputNombreUsuario.value)) {
             crearMensajeError("La nueva contraseña no puede ser similar al nombre de usuario.");
             bloquearEnvio();
         }
+
         if (await haSidoFiltradaEnBrechas(nuevaContrasena)) {
-            crearMensajeError("La nueva contraseña ha sido filtrada en brechas de seguridad. Por favor, elige una contraseña más segura.");
+            crearMensajeError(
+                "La nueva contraseña ha sido filtrada en brechas de seguridad. Por favor, elige una contraseña más segura.",
+            );
             bloquearEnvio();
         }
     };
 });
+
+export {};

--- a/admin/ts/edit_admin.ts
+++ b/admin/ts/edit_admin.ts
@@ -1,78 +1,111 @@
 import { limpiarInput } from "../../js/helpers/clean_input.js";
 import { UNITY_TYPE } from "../../js/constants.js";
 import { verifyMaliciousPhoto } from "./helpers/verify_malicious_photo.js";
-function getForm() {
+
+type VerificationResult = Awaited<ReturnType<typeof verifyMaliciousPhoto>>;
+
+type UnityValues = (typeof UNITY_TYPE)[keyof typeof UNITY_TYPE];
+
+function getForm(): HTMLFormElement {
     const form = document.getElementById("formulario-editar");
+
     if (!(form instanceof HTMLFormElement)) {
         throw new Error("No se encontró el formulario de edición de puestos.");
     }
+
     return form;
 }
-function getInputElement(id) {
+
+function getInputElement(id: string): HTMLInputElement {
     const element = document.getElementById(id);
+
     if (!(element instanceof HTMLInputElement)) {
         throw new Error(`No se encontró el elemento de formulario con id "${id}".`);
     }
+
     return element;
 }
-function getSelectElement(id) {
+
+function getSelectElement(id: string): HTMLSelectElement {
     const element = document.getElementById(id);
+
     if (!(element instanceof HTMLSelectElement)) {
         throw new Error(`No se encontró el elemento de selección con id "${id}".`);
     }
+
     return element;
 }
-function getOptionalInput(id) {
+
+function getOptionalInput(id: string): HTMLInputElement | null {
     const element = document.getElementById(id);
+
     if (element === null) {
         return null;
     }
+
     if (!(element instanceof HTMLInputElement)) {
         throw new Error(`El elemento con id "${id}" no es un campo de texto válido.`);
     }
+
     return element;
 }
-function validateCaseta(caseta) {
+
+function validateCaseta(caseta: string): string | null {
     if (!caseta) {
         return "Caseta, tipoUnity e idNave son obligatorios";
     }
+
     if (caseta.length !== 5) {
         return "Caseta debe ser una cadena de exactamente 5 caracteres";
     }
+
     const letras = caseta.substring(0, 2).toUpperCase();
     const numero = caseta.substring(2);
+
     if (!/^[0-9]{3}$/.test(numero)) {
         return "Las tres últimas posiciones de caseta deben ser números en el rango 001-370";
     }
+
     const numeroValor = Number.parseInt(numero, 10);
     const letrasValidas = new Set(["CE", "CO", "MC", "NA", "NC"]);
+
     if (!letrasValidas.has(letras) || numeroValor < 1 || numeroValor > 370) {
         return "Las dos primeras letras de caseta deben ser \"CE\", \"CO\", \"MC\", \"NA\", o \"NC\", y las tres últimas un número entre 001 y 370";
     }
+
     return null;
 }
-function validateCasetaPadre(casetaPadre) {
+
+function validateCasetaPadre(casetaPadre: string): string | null {
     if (casetaPadre === "") {
         return null;
     }
+
     if (casetaPadre.length !== 5) {
         return "Caseta padre, si se ha introducido, debe ser una cadena de exactamente 5 caracteres";
     }
+
     const letrasPadre = casetaPadre.substring(0, 2).toUpperCase();
     const numeroPadre = casetaPadre.substring(2);
+
     if (!/^[0-9]{3}$/.test(numeroPadre)) {
         return "Las tres últimas posiciones de caseta padre deben ser números con el formato 001-370";
     }
+
     const numeroPadreValor = Number.parseInt(numeroPadre, 10);
     const letrasValidas = new Set(["CE", "CO", "MC", "NA", "NC"]);
+
     if (!letrasValidas.has(letrasPadre) || numeroPadreValor < 1 || numeroPadreValor > 370) {
         return "Las dos primeras letras de caseta padre deben ser \"CE\", \"CO\", \"MC\", \"NA\", o \"NC\" y las tres últimas un número entre 001 y 370";
     }
+
     return null;
 }
-async function verifyImage(file) {
+
+async function verifyImage(file: File): Promise<VerificationResult> {
     return verifyMaliciousPhoto(file);
 }
+
 const formulario = getForm();
 const casetaInput = getInputElement("caseta");
 const tipoUnitySelect = getSelectElement("tipo-unity");
@@ -83,88 +116,108 @@ const contactoInput = getOptionalInput("contacto");
 const telefonoInput = getOptionalInput("telefono");
 const casetaPadreInput = getOptionalInput("caseta-padre");
 const imagenInput = getOptionalInput("imagen");
-function limpiarMensajesPrevios() {
+
+function limpiarMensajesPrevios(): void {
     const siguienteElemento = formulario.nextElementSibling;
+
     if (siguienteElemento instanceof HTMLDivElement && siguienteElemento.classList.contains("form-errors")) {
         siguienteElemento.remove();
     }
 }
-formulario.addEventListener("submit", async (event) => {
+
+formulario.addEventListener("submit", async (event: SubmitEvent) => {
     event.preventDefault();
     limpiarMensajesPrevios();
-    const errores = [];
+
+    const errores: string[] = [];
+
     const caseta = limpiarInput(casetaInput.value);
-    const tipoUnity = tipoUnitySelect.value;
+    const tipoUnity = tipoUnitySelect.value as UnityValues | string;
     const idNaveValor = Number.parseInt(idNaveSelect.value, 10);
+
     if (!caseta || !tipoUnity || Number.isNaN(idNaveValor)) {
         errores.push("Caseta, tipoUnity e idNave son obligatorios");
     }
+
     const errorCaseta = validateCaseta(caseta);
     if (errorCaseta) {
         errores.push(errorCaseta);
     }
-    const unityValues = Object.values(UNITY_TYPE);
+
+    const unityValues = Object.values(UNITY_TYPE) as readonly string[];
     if (!unityValues.includes(tipoUnity)) {
         errores.push("Tipo de unidad debe ser uno de los valores de UNITY_TYPE");
     }
+
     if (Number.isNaN(idNaveValor) || idNaveValor < 1 || idNaveValor > 12) {
         errores.push("El value de ID de nave debe estar entre 1 y 12");
     }
+
     const nombre = nombreInput ? limpiarInput(nombreInput.value) : "";
     const eliminarImagen = eliminarImagenInput ? limpiarInput(eliminarImagenInput.value) : "";
     const contacto = contactoInput ? limpiarInput(contactoInput.value) : "";
     const telefono = telefonoInput ? limpiarInput(telefonoInput.value) : "";
     const casetaPadre = casetaPadreInput ? limpiarInput(casetaPadreInput.value) : "";
+
     if (nombre && nombre.length > 50) {
         errores.push("El nombre, si se ha introducido, debe ser una cadena de máximo 50 caracteres");
     }
+
     if (eliminarImagen && (eliminarImagen !== "0" && eliminarImagen !== "1")) {
         errores.push("Eliminar imagen debe ser un entero con valor 0 o 1");
     }
+
     if (contacto && contacto.length > 250) {
         errores.push("Contacto, si se ha introducido, debe ser una cadena de máximo 250 caracteres");
     }
+
     if (telefono && telefono.length > 15) {
         errores.push("Teléfono, si se ha introducido, debe ser una cadena de máximo 15 caracteres");
     }
+
     const errorCasetaPadre = validateCasetaPadre(casetaPadre);
     if (errorCasetaPadre) {
         errores.push(errorCasetaPadre);
     }
+
     const archivo = imagenInput?.files?.[0] ?? null;
+
     if (archivo && archivo.size > 0) {
         const allowedTypes = new Set(["image/jpeg", "image/jpg"]);
         const maxSize = 2048 * 1024; // 2MB en bytes
+
         if (!allowedTypes.has(archivo.type)) {
             errores.push("La imagen debe ser un archivo .jpg o .jpeg válido");
-        }
-        else if (archivo.size > maxSize) {
+        } else if (archivo.size > maxSize) {
             errores.push("La imagen no puede ser mayor a 2MB");
-        }
-        else {
+        } else {
             try {
                 const verification = await verifyImage(archivo);
+
                 if (!verification.success) {
                     errores.push(verification.message || "No se pudo verificar la imagen.");
+                } else if (verification.isMalicious) {
+                    errores.push(
+                        verification.message
+                        || "La foto es maliciosa. Por favor, desinfecte el archivo o cargue una nueva imagen segura.",
+                    );
                 }
-                else if (verification.isMalicious) {
-                    errores.push(verification.message
-                        || "La foto es maliciosa. Por favor, desinfecte el archivo o cargue una nueva imagen segura.");
-                }
-            }
-            catch (error) {
+            } catch (error) {
                 console.error("Error en verificación de imagen:", error);
                 errores.push("Error al verificar la imagen. Por favor, inténtelo de nuevo.");
             }
         }
     }
+
     if (errores.length > 0) {
         alert(errores[0]);
+
         const div = document.createElement("div");
         div.classList.add("form-errors");
         div.innerHTML = `<ul style="color: red;">${errores.map((mensaje) => `<li>${mensaje}</li>`).join("")}</ul>`;
         formulario.insertAdjacentElement("afterend", div);
         return;
     }
+
     formulario.submit();
 });

--- a/admin/ts/edit_translations.ts
+++ b/admin/ts/edit_translations.ts
@@ -1,45 +1,60 @@
 import { limpiarTextarea } from "../../js/helpers/clean_input.js";
-function getForm() {
+
+function getForm(): HTMLFormElement {
     const form = document.getElementById("formulario");
+
     if (!(form instanceof HTMLFormElement)) {
         throw new Error("No se encontró el formulario de traducciones.");
     }
+
     return form;
 }
-function getDescripcionTextarea() {
+
+function getDescripcionTextarea(): HTMLTextAreaElement {
     const textarea = document.getElementById("descripcion");
+
     if (!(textarea instanceof HTMLTextAreaElement)) {
         throw new Error("No se encontró el campo de descripción.");
     }
+
     return textarea;
 }
-function getTipoInput() {
+
+function getTipoInput(): HTMLInputElement {
     const input = document.getElementById("tipo");
+
     if (!(input instanceof HTMLInputElement)) {
         throw new Error("No se encontró el campo de tipo.");
     }
+
     return input;
 }
+
 const formulario = getForm();
 const descripcionTextarea = getDescripcionTextarea();
 const tipoInput = getTipoInput();
-formulario.addEventListener("submit", (event) => {
+
+formulario.addEventListener("submit", (event: SubmitEvent) => {
     let errorMessages = "";
     let errorExist = false;
+
     const descripcion = limpiarTextarea(descripcionTextarea.value);
     const tipo = tipoInput.value;
+
     if (descripcion !== "" && descripcion.length > 450) {
         event.preventDefault();
         alert("La descripción, si se ha introducido, debe tener un máximo de 450 caracteres");
         errorMessages += "<li>La descripción, si se ha introducido, debe tener un máximo de 450 caracteres</li>";
         errorExist = true;
     }
+
     if (tipo.length > 50) {
         event.preventDefault();
         alert("El tipo no puede tener más de 50 caracteres");
         errorMessages += "<li>El tipo no puede tener más de 50 caracteres</li>";
         errorExist = true;
     }
+
     if (errorExist) {
         event.preventDefault();
         const div = document.createElement("div");

--- a/admin/ts/helpers/password_generator.ts
+++ b/admin/ts/helpers/password_generator.ts
@@ -1,75 +1,107 @@
 import { limpiarInput } from "../../../../js/helpers/clean_input.js";
-function getForm() {
+
+declare global {
+    interface Window {
+        syncInputs: (inputType: "number" | "range") => void;
+        copyToClipboard: (passwordId: string) => Promise<void>;
+    }
+}
+
+function getForm(): HTMLFormElement {
     const form = document.getElementById("formulario-generacion-contrasena");
+
     if (!(form instanceof HTMLFormElement)) {
         throw new Error("No se encontró el formulario de generación de contraseñas.");
     }
+
     return form;
 }
-function getNumberInput() {
+
+function getNumberInput(): HTMLInputElement {
     const input = document.getElementById("length-number");
+
     if (!(input instanceof HTMLInputElement)) {
         throw new Error("No se encontró el campo numérico de longitud.");
     }
+
     return input;
 }
-function getRangeInput() {
+
+function getRangeInput(): HTMLInputElement {
     const input = document.getElementById("length-range");
+
     if (!(input instanceof HTMLInputElement)) {
         throw new Error("No se encontró el control deslizante de longitud.");
     }
+
     return input;
 }
-function getOutputElement() {
+
+function getOutputElement(): HTMLOutputElement {
     const output = document.getElementById("length-output");
+
     if (!(output instanceof HTMLOutputElement)) {
         throw new Error("No se encontró el elemento de salida de longitud.");
     }
+
     return output;
 }
+
 const formulario = getForm();
 const numberInput = getNumberInput();
 const rangeInput = getRangeInput();
 const output = getOutputElement();
-function actualizarSalida() {
+
+function actualizarSalida(): void {
     output.textContent = rangeInput.value;
 }
-window.syncInputs = (inputType) => {
+
+window.syncInputs = (inputType: "number" | "range") => {
     if (inputType === "number") {
         rangeInput.value = numberInput.value;
-    }
-    else {
+    } else {
         numberInput.value = rangeInput.value;
     }
+
     actualizarSalida();
 };
-window.copyToClipboard = async (passwordId) => {
+
+window.copyToClipboard = async (passwordId: string) => {
     const passwordText = document.getElementById(passwordId);
+
     if (!(passwordText instanceof HTMLElement)) {
         throw new Error(`No se encontró el elemento con id "${passwordId}".`);
     }
+
     const text = passwordText.innerText;
+
     try {
         await navigator.clipboard.writeText(text);
         alert("Contraseña copiada al portapapeles.");
-    }
-    catch (error) {
+    } catch (error) {
         console.error("Fallo al copiar la contraseña al portapapeles:", error);
     }
 };
-formulario.addEventListener("submit", (event) => {
+
+formulario.addEventListener("submit", (event: SubmitEvent) => {
     const longitudSanitizada = limpiarInput(numberInput.value);
     const longitudNumero = Number.parseInt(longitudSanitizada, 10);
     const longitudRango = Number.parseInt(rangeInput.value, 10);
-    if (Number.isNaN(longitudNumero)
+
+    if (
+        Number.isNaN(longitudNumero)
         || Number.isNaN(longitudRango)
         || longitudNumero < 16
         || longitudNumero > 500
         || longitudRango < 16
         || longitudRango > 500
-        || longitudNumero !== longitudRango) {
+        || longitudNumero !== longitudRango
+    ) {
         event.preventDefault();
         alert("La longitud debe ser un número natural entre 16 y 500");
     }
 });
+
 actualizarSalida();
+
+export {};

--- a/admin/ts/helpers/verify_malicious_photo.ts
+++ b/admin/ts/helpers/verify_malicious_photo.ts
@@ -1,24 +1,42 @@
+export interface VerifyMaliciousPhotoResult {
+    success: boolean;
+    isMalicious: boolean;
+    message: string;
+}
+
+interface VerifyMaliciousPhotoResponse {
+    success?: boolean;
+    is_malicious?: boolean;
+    isMalicious?: boolean;
+    message?: string;
+}
+
 const VERIFY_MALICIOUS_PHOTO_ENDPOINT = "/appventurers/helpers/verify_malicious_photo.php";
-export async function verifyMaliciousPhoto(file) {
+
+export async function verifyMaliciousPhoto(file: File): Promise<VerifyMaliciousPhotoResult> {
     try {
         const formData = new FormData();
         formData.append("imagen", file);
+
         const response = await fetch(VERIFY_MALICIOUS_PHOTO_ENDPOINT, {
             method: "POST",
             body: formData,
         });
+
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
         }
-        const result = await response.json();
+
+        const result: VerifyMaliciousPhotoResponse = await response.json();
+
         return {
             success: Boolean(result.success),
             isMalicious: Boolean(result.is_malicious ?? result.isMalicious),
             message: result.message ?? "",
         };
-    }
-    catch (error) {
+    } catch (error) {
         console.error("Error al comprobar la foto:", error);
+
         return {
             success: false,
             isMalicious: false,

--- a/admin/ts/index_admin.ts
+++ b/admin/ts/index_admin.ts
@@ -1,24 +1,34 @@
-function getFormElement() {
+function getFormElement(): HTMLFormElement {
     const form = document.getElementById("formulario-busqueda");
+
     if (!(form instanceof HTMLFormElement)) {
         throw new Error("No se encontró el formulario de búsqueda de puestos.");
     }
+
     return form;
 }
-function getSearchInput() {
+
+function getSearchInput(): HTMLInputElement {
     const input = document.getElementById("input-busqueda");
+
     if (!(input instanceof HTMLInputElement)) {
         throw new Error("No se encontró el campo de búsqueda de puestos.");
     }
+
     return input;
 }
+
 const formulario = getFormElement();
 const inputBusqueda = getSearchInput();
-formulario.addEventListener("submit", (event) => {
+
+formulario.addEventListener("submit", (event: SubmitEvent) => {
     const busqueda = inputBusqueda.value.trim();
+
     if (busqueda && /[<>"'%]/.test(busqueda)) {
         event.preventDefault();
         alert("Por favor, elimine los caracteres no permitidos, que son: <, >, \", ', %");
     }
 });
+
 export {};
+

--- a/admin/tsconfig.json
+++ b/admin/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ES2020",
+        "moduleResolution": "node",
+        "lib": [
+            "DOM",
+            "DOM.Iterable",
+            "ES2020"
+        ],
+        "rootDir": "ts",
+        "outDir": "js",
+        "strict": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "allowSyntheticDefaultImports": true,
+        "noEmitOnError": true
+    },
+    "include": [
+        "ts/**/*",
+        "../types/**/*.d.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "pracear-admin",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pracear-admin",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pracear-admin",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.json && tsc -p admin/tsconfig.json"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/ts/constants.ts
+++ b/ts/constants.ts
@@ -10,4 +10,6 @@ export const UNITY_TYPE = {
     "bread-sweets": "bread-sweets",
     flowers: "flowers",
     restaurants: "restaurants",
-};
+} as const;
+
+export type UnityType = typeof UNITY_TYPE[keyof typeof UNITY_TYPE];

--- a/ts/helpers/clean_input.ts
+++ b/ts/helpers/clean_input.ts
@@ -1,4 +1,4 @@
-function sanitizeText(value) {
+function sanitizeText(value: string): string {
     const trimmed = value.trim();
     const withoutBackslashes = trimmed.replace(/\\/g, "");
     const escapedHtml = withoutBackslashes
@@ -10,9 +10,11 @@ function sanitizeText(value) {
     const withoutHtmlTags = escapedHtml.replace(/<\/?[^>]+(>|$)/g, "");
     return unescape(encodeURIComponent(withoutHtmlTags));
 }
-export function limpiarInput(input) {
+
+export function limpiarInput(input: string): string {
     return sanitizeText(input);
 }
-export function limpiarTextarea(textarea) {
+
+export function limpiarTextarea(textarea: string): string {
     return sanitizeText(textarea);
 }

--- a/ts/helpers/verify_strong_password.ts
+++ b/ts/helpers/verify_strong_password.ts
@@ -3,15 +3,18 @@ const mayusculasRegex = /[A-Z]/;
 const numerosRegex = /[0-9]/;
 // Caracteres especiales permitidos: !@#$%^&*()-_=+[]{}|;:,.<>/
 const caracteresEspecialesRegex = /[!@#$%^&*()\-_=+\[\]{}|;:,.<>\/]/;
+
 const tecladoEspanolFilas = [
     "qwertyuiop",
     "asdfghjklñ",
     "zxcvbnm",
 ];
+
 const secuenciasDiagonalesTecladoEspanol = [
     "qaz", "wsx", "edc", "rfv", "tgb", "yhn", "ujm",
     "qazwsx", "wsxedc", "edcrfv", "rfvtgb", "tgbnhy", "yhnujm",
 ];
+
 const secuenciasCaracteresEspecialesInseguras = [
     "!@#$%^&*()_+",
     "-=",
@@ -22,73 +25,90 @@ const secuenciasCaracteresEspecialesInseguras = [
     ":\"",
     "<>?",
 ];
+
 const numeros = "0123456789";
 const numerosReverso = numeros.split("").reverse().join("");
 const secuenciasDiagonalesTecladoNumerico = [
     "159", "951", "753", "357", "147", "741", "369", "963", "258", "852",
 ];
-export function verifyStrongPassword(password) {
+
+export function verifyStrongPassword(password: string): boolean {
     if (password.length < 16 || password.length > 1024) {
         return false;
     }
+
     if (!minusculasRegex.test(password)) {
         return false;
     }
+
     if (!mayusculasRegex.test(password)) {
         return false;
     }
+
     if (!numerosRegex.test(password)) {
         return false;
     }
+
     let caracteresEspeciales = 0;
     for (const caracter of password) {
         if (caracteresEspecialesRegex.test(caracter)) {
             caracteresEspeciales += 1;
         }
     }
+
     if (caracteresEspeciales < 3) {
         return false;
     }
+
     return true;
 }
-async function sha1Hash(password) {
+
+async function sha1Hash(password: string): Promise<string> {
     const encoder = new TextEncoder();
     const data = encoder.encode(password);
     const hashBuffer = await window.crypto.subtle.digest("SHA-1", data);
     const hashArray = Array.from(new Uint8Array(hashBuffer));
     return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("").toUpperCase();
 }
-export async function haSidoFiltradaEnBrechas(password) {
+
+export async function haSidoFiltradaEnBrechas(password: string): Promise<boolean> {
     const hash = (await sha1Hash(password)).toUpperCase();
     const hashPrefix = hash.substring(0, 5);
     const hashSuffix = hash.substring(5);
     const url = `https://api.pwnedpasswords.com/range/${hashPrefix}`;
+
     try {
         const response = await fetch(url);
+
         if (!response.ok) {
             console.error("Error al acceder a la API de brechas de seguridad.");
             return false;
         }
+
         const data = await response.text();
         const hashes = data.split("\n");
+
         return hashes.some((hashLine) => {
             const [hashPart] = hashLine.split(":");
             return hashPart.trim() === hashSuffix;
         });
-    }
-    catch (error) {
+    } catch (error) {
         console.error("Error al comprobar la contraseña:", error);
         return false;
     }
 }
-export function contrasenhaSimilarAUsuario(contrasenha, usuario) {
+
+export function contrasenhaSimilarAUsuario(contrasenha: string, usuario: string | string[]): boolean {
     const contrasenhaMinusculas = contrasenha.toLowerCase();
     const usuarios = Array.isArray(usuario) ? usuario : [usuario];
+
     for (const nombreUsuario of usuarios) {
         const nombreUsuarioMinusculas = nombreUsuario.toLowerCase();
+
         if (contrasenhaMinusculas.includes(nombreUsuarioMinusculas)) {
             return true;
         }
+
         const longitud = nombreUsuarioMinusculas.length;
         for (let i = 0; i <= longitud - 3; i += 1) {
             const subcadena = nombreUsuarioMinusculas.substring(i, i + 3);
@@ -97,31 +117,40 @@ export function contrasenhaSimilarAUsuario(contrasenha, usuario) {
             }
         }
     }
+
     return false;
 }
-export function tieneSecuenciasNumericasInseguras(contrasenha) {
-    const secuenciasNumericasInseguras = [];
+
+export function tieneSecuenciasNumericasInseguras(contrasenha: string): boolean {
+    const secuenciasNumericasInseguras: string[] = [];
+
     for (let longitud = 2; longitud <= 5; longitud += 1) {
         for (let i = 0; i <= numeros.length - longitud; i += 1) {
             secuenciasNumericasInseguras.push(numeros.substring(i, i + longitud));
             secuenciasNumericasInseguras.push(numerosReverso.substring(i, i + longitud));
         }
     }
+
     for (const secuencia of secuenciasDiagonalesTecladoNumerico) {
         secuenciasNumericasInseguras.push(secuencia);
     }
+
     return secuenciasNumericasInseguras.some((secuencia) => contrasenha.includes(secuencia));
 }
-export function tieneSecuenciasAlfabeticasInseguras(contrasenha) {
+
+export function tieneSecuenciasAlfabeticasInseguras(contrasenha: string): boolean {
     const alfabeto = "abcdefghijklmnopqrstuvwxyz";
     const alfabetoReverso = alfabeto.split("").reverse().join("");
-    const secuenciasAlfabeticasInseguras = [];
+
+    const secuenciasAlfabeticasInseguras: string[] = [];
+
     for (let longitud = 2; longitud <= 5; longitud += 1) {
         for (let i = 0; i <= alfabeto.length - longitud; i += 1) {
             secuenciasAlfabeticasInseguras.push(alfabeto.substring(i, i + longitud));
             secuenciasAlfabeticasInseguras.push(alfabetoReverso.substring(i, i + longitud));
         }
     }
+
     for (const fila of tecladoEspanolFilas) {
         for (let longitud = 2; longitud <= fila.length; longitud += 1) {
             const filaReverso = fila.split("").reverse().join("");
@@ -131,12 +160,21 @@ export function tieneSecuenciasAlfabeticasInseguras(contrasenha) {
             }
         }
     }
-    const secuenciasDiagonalesTecladoEspanolReverso = secuenciasDiagonalesTecladoEspanol.map((secuencia) => secuencia.split("").reverse().join(""));
-    secuenciasAlfabeticasInseguras.push(...secuenciasDiagonalesTecladoEspanol, ...secuenciasDiagonalesTecladoEspanolReverso);
+
+    const secuenciasDiagonalesTecladoEspanolReverso = secuenciasDiagonalesTecladoEspanol.map(
+        (secuencia) => secuencia.split("").reverse().join("")
+    );
+    secuenciasAlfabeticasInseguras.push(
+        ...secuenciasDiagonalesTecladoEspanol,
+        ...secuenciasDiagonalesTecladoEspanolReverso,
+    );
+
     return secuenciasAlfabeticasInseguras.some((secuencia) => contrasenha.includes(secuencia));
 }
-export function tieneSecuenciasDeCaracteresEspecialesInseguras(contrasenha) {
+
+export function tieneSecuenciasDeCaracteresEspecialesInseguras(contrasenha: string): boolean {
     const longitud = contrasenha.length;
+
     for (const secuencia of secuenciasCaracteresEspecialesInseguras) {
         const longitudSecuencia = secuencia.length;
         for (let i = 0; i <= longitud - longitudSecuencia; i += 1) {
@@ -146,8 +184,10 @@ export function tieneSecuenciasDeCaracteresEspecialesInseguras(contrasenha) {
             }
         }
     }
+
     return false;
 }
-export function tieneEspaciosAlPrincipioOAlFinal(contrasenha) {
+
+export function tieneEspaciosAlPrincipioOAlFinal(contrasenha: string): boolean {
     return contrasenha.startsWith(" ") || contrasenha.endsWith(" ");
 }

--- a/ts/login.ts
+++ b/ts/login.ts
@@ -1,64 +1,90 @@
-import { tieneSecuenciasAlfabeticasInseguras, tieneSecuenciasDeCaracteresEspecialesInseguras, tieneSecuenciasNumericasInseguras, } from "./helpers/verify_strong_password.js";
-function obtenerElementoFormulario(id, tipo) {
+import {
+    tieneSecuenciasAlfabeticasInseguras,
+    tieneSecuenciasDeCaracteresEspecialesInseguras,
+    tieneSecuenciasNumericasInseguras,
+} from "./helpers/verify_strong_password.js";
+
+type LoginFormElements = {
+    login: HTMLInputElement;
+    password: HTMLInputElement;
+};
+
+function obtenerElementoFormulario<T extends HTMLElement>(id: string, tipo: new () => T): T {
     const element = document.getElementById(id);
     if (!element) {
         throw new Error(`No se encontró el elemento con id "${id}".`);
     }
+
     if (!(element instanceof tipo)) {
         throw new Error(`El elemento con id "${id}" no es del tipo esperado.`);
     }
+
     return element;
 }
-function obtenerInputsFormulario() {
+
+function obtenerInputsFormulario(): LoginFormElements {
     const login = obtenerElementoFormulario("login", HTMLInputElement);
     const password = obtenerElementoFormulario("password", HTMLInputElement);
+
     return { login, password };
 }
+
 const formulario = document.getElementById("formulario");
+
 if (!(formulario instanceof HTMLFormElement)) {
     throw new Error("No se encontró el formulario de autenticación.");
 }
-formulario.addEventListener("submit", (event) => {
+
+formulario.addEventListener("submit", (event: SubmitEvent) => {
     const { login, password } = obtenerInputsFormulario();
     const loginValue = login.value.trim();
     const passwordValue = password.value.trim();
     const passwordOriginal = password.value;
+
     if (typeof loginValue !== "string" || typeof passwordValue !== "string") {
         event.preventDefault();
         alert("Error en el formulario.");
         return;
     }
+
     if (passwordOriginal !== passwordOriginal.trim()) {
         event.preventDefault();
         alert("La contraseña no puede contener espacios al principio o al final.");
         return;
     }
+
     const loginRegex = /^[a-zA-Z0-9._-]{3,50}$/;
+
     if (!loginValue) {
         event.preventDefault();
         alert("El campo de usuario no puede estar vacío.");
         return;
     }
+
     if (!loginRegex.test(loginValue)) {
         event.preventDefault();
         alert("El nombre de usuario debe tener entre 3 y 50 caracteres y solo puede contener letras, números, puntos, guiones y guiones bajos.");
         return;
     }
+
     if (/^[\d._-]/.test(loginValue)) {
         event.preventDefault();
         alert("El nombre de usuario no puede comenzar por un número, guion, guion bajo o punto.");
         return;
     }
+
     if (!passwordValue) {
         event.preventDefault();
         alert("El campo de contraseña no puede estar vacío.");
         return;
     }
+
     if (passwordValue.length < 16 || passwordValue.length > 1024) {
         event.preventDefault();
         alert("La contraseña debe tener entre 16 y 1024 caracteres.");
         return;
     }
+
     let numeroCaracteresEspeciales = 0;
     let numeroMayusculas = 0;
     let numeroMinusculas = 0;
@@ -67,28 +93,36 @@ formulario.addEventListener("submit", (event) => {
     const regexMinusculas = /[a-z]/;
     const regexMayusculas = /[A-Z]/;
     const regexNumeros = /[0-9]/;
+
     for (const caracter of passwordValue) {
         if (regexNumeros.test(caracter)) {
             numeroNumeros += 1;
         }
+
         if (regexMinusculas.test(caracter)) {
             numeroMinusculas += 1;
         }
+
         if (regexMayusculas.test(caracter)) {
             numeroMayusculas += 1;
         }
+
         if (regexCaracteresEspeciales.test(caracter)) {
             numeroCaracteresEspeciales += 1;
         }
     }
+
     if (numeroMayusculas < 1 || numeroMinusculas < 1 || numeroNumeros < 1 || numeroCaracteresEspeciales < 3) {
         event.preventDefault();
         alert("La contraseña debe tener al menos una letra mayúscula, una letra minúscula, un número y tres caracteres especiales distintos.");
         return;
     }
-    if (tieneSecuenciasAlfabeticasInseguras(passwordValue)
+
+    if (
+        tieneSecuenciasAlfabeticasInseguras(passwordValue)
         || tieneSecuenciasDeCaracteresEspecialesInseguras(passwordValue)
-        || tieneSecuenciasNumericasInseguras(passwordValue)) {
+        || tieneSecuenciasNumericasInseguras(passwordValue)
+    ) {
         event.preventDefault();
         alert("La contraseña no puede contener secuencias alfabéticas, de caracteres especiales o numéricas inseguras como \"abc\", \"qwerty\", \"qaz\", \"123\", \"147\", \"159\"");
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ES2020",
+        "moduleResolution": "node",
+        "lib": [
+            "DOM",
+            "DOM.Iterable",
+            "ES2020"
+        ],
+        "rootDir": "ts",
+        "outDir": "js",
+        "strict": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "allowSyntheticDefaultImports": true,
+        "noEmitOnError": true,
+        "allowImportingTsExtensions": false
+    },
+    "include": [
+        "ts/**/*",
+        "types/**/*.d.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/types/js-modules.d.ts
+++ b/types/js-modules.d.ts
@@ -1,0 +1,18 @@
+declare module "*js/helpers/clean_input.js" {
+    export function limpiarInput(input: string): string;
+    export function limpiarTextarea(textarea: string): string;
+}
+
+declare module "*js/helpers/verify_strong_password.js" {
+    export function verifyStrongPassword(password: string): boolean;
+    export function haSidoFiltradaEnBrechas(password: string): Promise<boolean>;
+    export function contrasenhaSimilarAUsuario(contrasenha: string, usuario: string | string[]): boolean;
+    export function tieneSecuenciasNumericasInseguras(contrasenha: string): boolean;
+    export function tieneSecuenciasAlfabeticasInseguras(contrasenha: string): boolean;
+    export function tieneSecuenciasDeCaracteresEspecialesInseguras(contrasenha: string): boolean;
+    export function tieneEspaciosAlPrincipioOAlFinal(contrasenha: string): boolean;
+}
+
+declare module "*js/constants.js" {
+    export const UNITY_TYPE: Record<string, string>;
+}


### PR DESCRIPTION
## Summary
- add an admin TypeScript build that mirrors the existing JavaScript bundle structure
- reimplement every admin form script in TypeScript with runtime DOM guards and detailed validations
- provide type declarations for shared JavaScript helpers so both projects compile cleanly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d517ffac288325bf6ec386e914da93