### PR TITLE
feat: refresh admin dark mode theming

### DIFF
--- a/admin/change_password.php
+++ b/admin/change_password.php
@@ -7,7 +7,10 @@
         <title>Admin - PraceAR - Cambiar Contraseña</title>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
         <style>
-            <?php require_once(CSS_ADMIN . 'header.css'); ?>
+            <?php
+            require_once(CSS_ADMIN . 'theme.css');
+            require_once(CSS_ADMIN . 'header.css');
+            ?>
             /* body {
                 max-width: 80%;
                 margin: 0 auto;
@@ -37,7 +40,8 @@
                 max-width: 1200px;
                 background: var(--pico-card-background-color, #fff);
                 border-radius: var(--pico-border-radius, 0.5rem);
-                box-shadow: 0 2px 16px rgba(0,0,0,0.06);
+                box-shadow: var(--admin-card-shadow);
+                border: 1px solid var(--admin-border);
                 padding: 2rem 2.5rem;
                 gap: 1.2rem;
             }
@@ -141,6 +145,7 @@
             }
         }
         </style>
+        <link rel="stylesheet" href="./css/darkmode.css">
     <link rel='icon' href='./img/favicon.png' type='image/png'>
     
     <link rel="apple-touch-icon" sizes="180x180" href="./img/apple-touch-icon-180x180.png">
@@ -386,7 +391,7 @@
             header("refresh:2;url=$protocolo/$servidor/$subdominio"); */
             exit;
         } catch (Exception $e) {
-            $err = '<span style="color: red; text-align: center;">' . htmlspecialchars($e->getMessage() ?? 'Error desconocido') . '</span>';
+            $err = '<span class="admin-error-text" style="text-align: center;">' . htmlspecialchars($e->getMessage() ?? 'Error desconocido') . '</span>';
         }
     }
 
@@ -407,19 +412,19 @@
                 disabled aria-disabled="true">
         </div>
         <div id="form-group">
-            <label for="old-password">Contraseña actual: <span style="color: red;" aria-hidden="true">*</span></label>
+            <label for="old-password">Contraseña actual: <span class="admin-required" aria-hidden="true">*</span></label>
             <input type="password" name="old_password" id="old-password" required aria-describedby="password-help">
             <p id="password-help" class="sr-only">Introduce tu contraseña actual.</p>
         </div>
         <div id="form-group">
-            <label for="new-password">Nueva contraseña: <span style="color: red;" aria-hidden="true">*</span></label>
+            <label for="new-password">Nueva contraseña: <span class="admin-required" aria-hidden="true">*</span></label>
             <input type="password" name="new_password" id="new-password" required onblur="if(this.value) checkPasswordRequirements()"
                 aria-describedby="new-password-help">
             <p id="new-password-help" class="sr-only">Introduce una nueva contraseña que cumpla con los requisitos.</p>
         </div>
         <div id="form-group">
-            <label for="confirm-password">Confirmar nueva contraseña: <span style="color: red;"
-                    aria-hidden="true">*</span></label>
+            <label for="confirm-password">Confirmar nueva contraseña: <span class="admin-required"
+            aria-hidden="true">*</span></label>
             <input type="password" name="confirm_password" id="confirm-password" required
                 aria-describedby="confirm-password-help">
             <p id="confirm-password-help" class="sr-only">Introduce nuevamente la nueva contraseña para confirmarla.</p>
@@ -445,9 +450,9 @@
             <input type="submit" value="Cambiar contraseña" aria-label="Cambiar contraseña">
         </div>
     </form>
-    <p style="color: red; text-align: center;">Los campos marcados con <span style="color: red;">*</span> son
+    <p class="admin-error-text" style="text-align: center;">Los campos marcados con <span class="admin-required" aria-hidden="true">*</span> son
         obligatorios</p>
-    <span id="help-text" style="color: blue;">¿Necesita ayuda? Le recomendamos que use un navegador con gestor y generador de
+    <span id="help-text" class="admin-info-text">¿Necesita ayuda? Le recomendamos que use un navegador con gestor y generador de
         contraseñas
         integrados, como Google
         Chrome o Mozilla Firefox, con la sesión iniciada en su cuenta de Google o Firefox, respectivamente. De esta

--- a/admin/css/edit_admin.css
+++ b/admin/css/edit_admin.css
@@ -4,8 +4,8 @@ body {
     line-height: 1.25;
     margin: 0 auto;
     /* padding: 1em; */
-    background-color: #f4f4f4;
-    color: #333;
+    background-color: var(--admin-bg);
+    color: var(--admin-text);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -43,16 +43,19 @@ footer {
 
 /* Estilos de tablas */
 table {
-    border: 1px solid #ccc;
+    border: 1px solid var(--admin-table-border);
     border-collapse: collapse;
     margin: 0;
     padding: 0;
     width: 100%;
     table-layout: fixed;
+    background-color: var(--admin-surface);
 }
 
 thead {
     font-size: .95em;
+    background-color: var(--admin-table-header-bg);
+    color: var(--admin-table-header-text);
 }
 
 tbody {
@@ -66,9 +69,13 @@ tbody {
 }
 
 table tr {
-    background-color: #f8f8f8;
-    border: 1px solid #ddd;
+    background-color: var(--admin-table-row-bg);
+    border: 1px solid var(--admin-table-border);
     padding: .35em;
+}
+
+table tbody tr:nth-child(even) {
+    background-color: var(--admin-table-row-alt-bg);
 }
 
 table th,
@@ -83,7 +90,7 @@ table th {
 }
 
 .imagen-bandera {
-    box-shadow: 0 0 2px 1px black;
+    box-shadow: 0 0 2px 1px var(--admin-border-strong);
 }
 
 #contenedor-separacion {
@@ -98,7 +105,7 @@ table th {
     width: 100%;
     height: 100%;
     overflow-y: auto;
-    background-color: rgba(0, 0, 0, 0.8);
+    background-color: var(--admin-overlay-background);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -121,8 +128,9 @@ table th {
     max-width: 100%;
     max-height: 80vh;
     border-radius: 10px;
-    box-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
+    box-shadow: var(--admin-overlay-shadow);
     transition: transform 0.3s ease;
+    background-color: var(--admin-surface);
 }
 
 .zoomed-container img:hover {
@@ -130,7 +138,7 @@ table th {
 }
 
 .zoomed-container p {
-    color: white;
+    color: var(--admin-overlay-text);
     font-size: 1.5rem;
     margin-top: 30px;
     text-align: center;
@@ -149,7 +157,7 @@ table th {
     top: 0;
     right: 0;
     font-size: 2.25rem;
-    color: white;
+    color: var(--admin-overlay-text);
     cursor: pointer;
     background: none;
     border: none;
@@ -174,22 +182,23 @@ table th {
 
 .paginacion a {
     padding: 8px 12px;
-    border: 1px solid #1e7dbd;
+    border: 1px solid var(--admin-pagination-border);
     text-decoration: none;
-    color: #1e7dbd;
+    color: var(--admin-pagination-text);
     border-radius: 4px;
     transition: background-color 0.3s ease, color 0.3s ease;
+    background-color: transparent;
 }
 
 .paginacion a:hover {
-    background-color: #1e7dbd;
-    color: white;
+    background-color: var(--admin-pagination-hover-bg);
+    color: var(--admin-pagination-hover-color);
 }
 
 .paginacion a.activo {
-    background-color: #1e7dbd;
-    color: white;
-    border-color: #1e7dbd;
+    background-color: var(--admin-pagination-hover-bg);
+    color: var(--admin-pagination-hover-color);
+    border-color: var(--admin-pagination-border);
     font-weight: bold;
     border-radius: 5px;
 }

--- a/admin/css/header.css
+++ b/admin/css/header.css
@@ -6,12 +6,16 @@
   flex-direction: column;
   align-items: center;
   gap: 1.5rem;
-  background: linear-gradient(135deg, #667eea 0%, #3b82f6 100%);
+  background: linear-gradient(
+    135deg,
+    var(--admin-header-gradient-start) 0%,
+    var(--admin-header-gradient-end) 100%
+  );
   padding: 2rem 1.5rem;
   margin-bottom: 2rem;
   /* border-radius: 16px; */
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.12);
-  color: white;
+  box-shadow: var(--admin-header-shadow);
+  color: var(--admin-header-text-color);
   position: relative;
   overflow: hidden;
   animation: headerSlideIn 0.6s ease-out;
@@ -24,7 +28,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--admin-header-overlay);
   z-index: 0;
 }
 
@@ -46,28 +50,28 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.95rem;
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--admin-nav-chip-bg);
   padding: 0.75rem 1rem;
   border-radius: 25px;
   transition: all 0.3s ease;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: white;
+  border: 1px solid var(--admin-nav-chip-border);
+  color: var(--admin-header-text-color);
   font-weight: 500;
 }
 
 .admin-header__language:hover {
-  background: rgba(255, 255, 255, 0.25);
+  background: var(--admin-nav-chip-hover-bg);
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--admin-nav-chip-hover-shadow);
 }
 
 .language-flag {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--admin-flag-shadow);
   width: 18px;
   height: 18px;
   border-radius: 4px;
   transition: transform 0.2s ease;
-  border: 2px solid rgba(255, 255, 255, 0.3);
+  border: 2px solid var(--admin-flag-border);
 }
 
 .language-flag:hover {
@@ -76,8 +80,8 @@
 
 .current-language-flag {
   border-radius: 4px;
-  border: 2px solid rgba(255, 255, 255, 0.9);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  border: 2px solid var(--admin-flag-current-border);
+  box-shadow: var(--admin-flag-shadow);
 }
 
 #cabecera_pagina_edicion {
@@ -86,10 +90,14 @@
   padding: 0.5rem !important;
   font-weight: 700;
   text-align: center;
-  background: linear-gradient(45deg, #ffffff, #e0e7ff);
+  background: linear-gradient(
+    45deg,
+    var(--admin-heading-gradient-start),
+    var(--admin-heading-gradient-end)
+  );
   -webkit-background-clip: text;
   background-clip: text;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-shadow: var(--admin-heading-shadow);
   letter-spacing: -0.02em;
   line-height: 1.2;
 }
@@ -118,24 +126,24 @@
 
 .flags a {
   text-decoration: none;
-  color: black;
+  color: var(--admin-link);
 }
 
 .flags a img {
-  box-shadow: 0 0 2px 1px black;
+  box-shadow: 0 0 2px 1px var(--admin-border-strong);
 }
 
 /* --- NUEVO: nav-link --- */
 .nav-link {
   text-decoration: none;
-  color: inherit;
+  color: var(--admin-header-link-color);
   position: relative;
   padding: 0.75rem 1.5rem;
   border-radius: 25px;
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--admin-nav-chip-bg);
   backdrop-filter: blur(10px);
   transition: all 0.3s ease;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--admin-nav-chip-border);
   white-space: nowrap;
   font-weight: 600;
 }
@@ -160,15 +168,15 @@
 
 .nav-link:hover,
 .nav-link:focus-visible {
-  background: rgba(255, 255, 255, 0.25);
+  background: var(--admin-nav-chip-hover-bg);
   transform: translateY(-3px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
-  color: white;
+  box-shadow: var(--admin-nav-chip-hover-shadow);
+  color: var(--admin-header-text-color);
 }
 
 /* --- NUEVO: texto-azul --- */
 .texto-azul {
-  color: blue;
+  color: var(--admin-info);
 }
 
 /* --- NUEVO: enlace_cierre_sesion img --- */
@@ -194,7 +202,7 @@
   flex-wrap: wrap;
   justify-content: center;
   font-size: clamp(0.95rem, 2.5vw, 1.15rem);
-  color: white !important;
+  color: var(--admin-header-link-color) !important;
   font-weight: 600;
 }
 

--- a/admin/css/index_admin.css
+++ b/admin/css/index_admin.css
@@ -6,6 +6,8 @@ body {
     line-height: 1.25;
     margin: 0;
     padding: 0;
+    background-color: var(--admin-bg);
+    color: var(--admin-text);
 }
 
 main {
@@ -31,16 +33,19 @@ footer {
 
 /* Estilos de tablas */
 table {
-    border: 1px solid #ccc;
+    border: 1px solid var(--admin-table-border);
     border-collapse: collapse;
     margin: 0;
     padding: 0;
     width: 100%;
     table-layout: fixed;
+    background-color: var(--admin-surface);
 }
 
 thead {
     font-size: .95em;
+    background-color: var(--admin-table-header-bg);
+    color: var(--admin-table-header-text);
 }
 
 tbody {
@@ -54,9 +59,13 @@ tbody {
 }
 
 table tr {
-    background-color: #f8f8f8;
-    border: 1px solid #ddd;
+    background-color: var(--admin-table-row-bg);
+    border: 1px solid var(--admin-table-border);
     padding: .35em;
+}
+
+table tbody tr:nth-child(even) {
+    background-color: var(--admin-table-row-alt-bg);
 }
 
 table th,
@@ -71,7 +80,7 @@ table th {
 }
 
 .imagen-bandera {
-    box-shadow: 0 0 2px 1px black;
+    box-shadow: 0 0 2px 1px var(--admin-border-strong);
 }
 
 #contenedor-separacion {
@@ -86,7 +95,7 @@ table th {
     width: 100%;
     height: 100%;
     overflow-y: auto;
-    background-color: rgba(0, 0, 0, 0.8);
+    background-color: var(--admin-overlay-background);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -109,8 +118,9 @@ table th {
     max-width: 100%;
     max-height: 80vh;
     border-radius: 10px;
-    box-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
+    box-shadow: var(--admin-overlay-shadow);
     transition: transform 0.3s ease;
+    background-color: var(--admin-surface);
 }
 
 .zoomed-container img:hover {
@@ -118,7 +128,7 @@ table th {
 }
 
 .zoomed-container p {
-    color: white;
+    color: var(--admin-overlay-text);
     font-size: 1.5rem;
     margin-top: 30px;
     text-align: center;
@@ -137,7 +147,7 @@ table th {
     top: 0;
     right: 0;
     font-size: 2.25rem;
-    color: white;
+    color: var(--admin-overlay-text);
     cursor: pointer;
     background: none;
     border: none;
@@ -162,22 +172,23 @@ table th {
 
 .paginacion a {
     padding: 8px 12px;
-    border: 1px solid #1e7dbd;
+    border: 1px solid var(--admin-pagination-border);
     text-decoration: none;
-    color: #1e7dbd;
+    color: var(--admin-pagination-text);
     border-radius: 4px;
     transition: background-color 0.3s ease, color 0.3s ease;
+    background-color: transparent;
 }
 
 .paginacion a:hover {
-    background-color: #1e7dbd;
-    color: white;
+    background-color: var(--admin-pagination-hover-bg);
+    color: var(--admin-pagination-hover-color);
 }
 
 .paginacion a.activo {
-    background-color: #1e7dbd;
-    color: white;
-    border-color: #1e7dbd;
+    background-color: var(--admin-pagination-hover-bg);
+    color: var(--admin-pagination-hover-color);
+    border-color: var(--admin-pagination-border);
     font-weight: bold;
     border-radius: 5px;
 }

--- a/admin/css/market_sections.php
+++ b/admin/css/market_sections.php
@@ -1,233 +1,133 @@
-<style>
-     html, body {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-            background: #f8f9fa;
-        }
+body {
+    max-width: 80%;
+    margin: 0 auto;
+    padding: 1em;
+    font-family: Arial, sans-serif;
+    background-color: var(--admin-bg);
+    color: var(--admin-text);
+}
 
-        body {
-            max-width: 80%;
-            margin: 0 auto;
-            padding: 1em;
-            font-family: Arial, sans-serif;
-            background-color: #f4f4f4;
-            color: #333;
-        }
+main.maps {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem 1rem;
+    max-width: 1200px;
+    margin: 0 auto;
+    gap: 1.5rem;
+}
 
-        main.maps {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            padding: 2rem 1rem;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
+main.maps h2 {
+    text-align: center;
+    margin-bottom: 0.5rem;
+    color: var(--admin-heading);
+}
 
-        main.maps h2 {
-            text-align: center;
-            margin-bottom: 2rem;
-        }
+.maps-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2.5rem;
+    width: 100%;
+    max-width: 1100px;
+    margin: 0 auto;
+}
 
-        .maps-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 2.5rem;
-            width: 100%;
-            max-width: 1100px;
-            margin: 0 auto;
-        }
+.maps-grid figure {
+    margin: 0;
+    border-radius: 16px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: var(--admin-map-card-bg);
+    overflow: hidden;
+    box-shadow: var(--admin-map-card-shadow);
+    border: 1px solid var(--admin-border);
+}
 
-        .maps-grid figure {
-            margin: 0;
-            box-shadow: 0 2px 12px rgba(0,0,0,0.08);
-            border-radius: 16px;
-            transition: transform 0.2s;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            background: #fff;
-            overflow: hidden;
-        }
+.maps-grid figure img {
+    width: 100%;
+    max-width: 350px;
+    min-height: 220px;
+    border-radius: 16px 16px 0 0;
+    object-fit: cover;
+    display: block;
+}
 
-        .maps-grid figure img {
-            width: 100%;
-            max-width: 350px;
-            min-height: 220px;
-            /* aspect-ratio: 16/10; */
-            border-radius: 16px 16px 0 0;
-            object-fit: cover;
-            display: block;
-        }
+.maps-grid figure figcaption {
+    padding: 1rem;
+    text-align: center;
+    font-size: 1.1rem;
+    background: var(--admin-map-caption-bg);
+    width: 100%;
+    box-sizing: border-box;
+    color: var(--admin-text);
+    border-top: 1px solid var(--admin-border);
+}
 
-        .maps-grid figure figcaption {
-            padding: 1rem 1rem;
-            text-align: center;
-            font-size: 1.1rem;
-            background: #f8f9fa;
-            border-radius: 0 0 16px 16px;
-            width: 100%;
-            box-sizing: border-box;
-            color: #333;
-        }
+.maps-grid figure:focus,
+.maps-grid figure:hover {
+    outline: 2px solid var(--admin-map-outline);
+    transform: scale(1.04);
+    cursor: pointer;
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
+}
 
-        .maps-grid figure:focus,
-        .maps-grid figure:hover {
-            outline: 2px solid #0078d4;
-            transform: scale(1.04);
-            cursor: pointer;
-        }
+.zoomed-container {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: var(--admin-overlay-background);
+    justify-content: center;
+    align-items: center;
+    padding: 1rem;
+    box-sizing: border-box;
+    overflow: auto;
+}
 
-        /* Zoomed container styles */
-        .zoomed-container {
-            display: none;
-            position: fixed;
-            z-index: 1000;
-            top: 0;
-            left: 0;
-            width: 100vw;
-            background: rgba(0, 0, 0, 0.8);
-            justify-content: center;
-            align-items: center;
-            padding: 1rem;
-            box-sizing: border-box;
-            overflow: auto;
-        }
-        .zoomed-container.show {
-            display: flex;
-        }
-        .zoomed-container img {
-            max-width: 96vw;
-            max-height: 90vh;
-            border-radius: 16px;
-            background: #fff;
-            box-shadow: 0 4px 32px rgba(0,0,0,0.25);
-        }
-        .zoomed-container figcaption {
-            color: #fff;
-            margin-top: 1rem;
-            font-size: 1.3rem;
-            text-align: center;
-        }
+.zoomed-container.show {
+    display: flex;
+}
 
-        @media (max-width: 1100px) {
-            .maps-grid {
-                grid-template-columns: repeat(2, 1fr);
-                gap: 2rem;
-            }
-        }
-        @media (max-width: 700px) {
-            .maps-grid {
-                grid-template-columns: 1fr;
-                gap: 1.5rem;
-            }
-            .maps-grid figure img {
-                max-width: 98vw;
-                min-height: 160px;
-            }
-        }
+.zoomed-container img {
+    max-width: 96vw;
+    max-height: 90vh;
+    border-radius: 16px;
+    background: var(--admin-surface);
+    box-shadow: var(--admin-overlay-shadow);
+}
 
-    .maps {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-        gap: 20px;
-        padding: 20px;
+.zoomed-container figcaption {
+    color: var(--admin-overlay-text);
+    margin-top: 1rem;
+    font-size: 1.3rem;
+    text-align: center;
+}
 
-        img {
-            /* width: 100%; */
-            height: auto;
-            border-radius: 5px;
-            transition: transform 0.3s ease;
-            cursor: pointer;
-        }
+@media (max-width: 1100px) {
+    .maps-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 2rem;
+    }
+}
 
-        h2 {
-            grid-column: 1 / -1;
-            text-align: center;
-        }
-
-        figure {
-            margin: 0;
-            padding: 0;
-            text-align: center;
-            position: relative;
-            cursor: pointer;
-        }
-
-        figcaption {
-            margin-top: 10px;
-            font-size: .5rem;
-        }
+@media (max-width: 700px) {
+    body {
+        max-width: 100%;
+        padding: 0.75rem;
     }
 
-
-    .zoom {
-        transition: transform 0.2s;
+    .maps-grid {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
     }
 
-    /* Estilo para la imagen en zoom centrada */
-    .zoomed-container {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100vw;
-        height: 100vh;
-        background-color: rgba(0, 0, 0, 0.8);
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        z-index: 9999;
-        visibility: hidden;
-        opacity: 0;
-        transition: visibility 0s, opacity 0.3s ease;
-        line-height: 0.003;
+    .maps-grid figure img {
+        max-width: 98vw;
+        min-height: 200px;
     }
-
-    /* Hacemos la imagen más grande */
-    .zoomed-container img {
-        max-width: 95%;
-        max-height: 90%;
-        border-radius: 10px;
-        box-shadow: 0px 0px 10px rgba(255, 255, 255, 0.8);
-    }
-
-    .zoomed-container.show {
-        visibility: visible;
-        opacity: 1;
-    }
-
-    .zoomed-container img:hover {
-        transform: scale(1.05);
-    }
-
-    .zoomed-container figcaption {
-        color: white;
-        margin-top: 37px;
-        font-size: 1.5rem;
-        text-align: center;
-    }
-
-    .zoomed-container::before {
-        content: '×';
-        position: absolute;
-        top: 10px;
-        right: 30px; /* Separado hacia la izquierda del borde derecho */
-        font-size: 2rem;
-        color: white;
-        cursor: pointer;
-        line-height: 1;
-    }
-
-    @media screen and (max-width: 768px) {
-        .maps {
-            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-        }
-    }
-
-    @media screen and (max-width: 480px) {
-        .maps {
-            grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-        }
-    }
-</style>
+}

--- a/admin/css/theme.css
+++ b/admin/css/theme.css
@@ -1,0 +1,178 @@
+:root {
+    color-scheme: light;
+    --admin-bg: #f4f4f4;
+    --admin-surface: #ffffff;
+    --admin-surface-muted: #f8f8f8;
+    --admin-surface-subtle: #eef2f6;
+    --admin-border: #d7dbe5;
+    --admin-border-strong: #c4c9d4;
+    --admin-text: #1f2933;
+    --admin-text-muted: #4b5563;
+    --admin-heading: #101828;
+    --admin-inverse-text: #ffffff;
+    --admin-link: #1e7dbd;
+    --admin-link-hover: #16639a;
+    --admin-primary: #1e7dbd;
+    --admin-primary-hover: #16639a;
+    --admin-primary-soft: rgba(30, 125, 189, 0.12);
+    --admin-primary-contrast: #ffffff;
+    --admin-success: #2f9e44;
+    --admin-success-hover: #248232;
+    --admin-error: #e63946;
+    --admin-info: #2563eb;
+    --admin-header-gradient-start: #667eea;
+    --admin-header-gradient-end: #3b82f6;
+    --admin-header-overlay: rgba(255, 255, 255, 0.08);
+    --admin-header-shadow: 0 10px 40px rgba(15, 23, 42, 0.12);
+    --admin-header-text-color: #ffffff;
+    --admin-header-link-color: #ffffff;
+    --admin-nav-chip-bg: rgba(255, 255, 255, 0.15);
+    --admin-nav-chip-border: rgba(255, 255, 255, 0.2);
+    --admin-nav-chip-hover-bg: rgba(255, 255, 255, 0.25);
+    --admin-nav-chip-hover-shadow: 0 8px 25px rgba(15, 23, 42, 0.2);
+    --admin-flag-border: rgba(255, 255, 255, 0.3);
+    --admin-flag-current-border: rgba(255, 255, 255, 0.9);
+    --admin-flag-shadow: 0 2px 8px rgba(15, 23, 42, 0.3);
+    --admin-table-header-bg: #ffffff;
+    --admin-table-header-text: #101828;
+    --admin-table-row-bg: #f8f8f8;
+    --admin-table-row-alt-bg: #eef2f6;
+    --admin-table-border: #d7dbe5;
+    --admin-pagination-border: var(--admin-primary);
+    --admin-pagination-text: var(--admin-primary);
+    --admin-pagination-hover-bg: var(--admin-primary);
+    --admin-pagination-hover-color: var(--admin-primary-contrast);
+    --admin-overlay-background: rgba(15, 23, 42, 0.82);
+    --admin-overlay-text: #ffffff;
+    --admin-overlay-shadow: 0 0 16px rgba(15, 23, 42, 0.35);
+    --admin-card-shadow: 0 2px 16px rgba(15, 23, 42, 0.08);
+    --admin-map-card-bg: #ffffff;
+    --admin-map-card-shadow: 0 2px 12px rgba(15, 23, 42, 0.08);
+    --admin-map-caption-bg: #f8f9fa;
+    --admin-map-outline: #1e7dbd;
+    --admin-heading-gradient-start: #ffffff;
+    --admin-heading-gradient-end: #e0e7ff;
+    --admin-heading-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+    --pico-background-color: var(--admin-bg);
+    --pico-color: var(--admin-text);
+    --pico-primary: var(--admin-primary);
+    --pico-primary-inverse: var(--admin-primary-contrast);
+    --pico-primary-background: var(--admin-primary);
+    --pico-primary-hover-background: var(--admin-primary-hover);
+    --pico-card-background-color: var(--admin-surface);
+    --pico-form-element-background-color: var(--admin-surface-muted);
+    --pico-muted-color: var(--admin-text-muted);
+    --pico-muted-border-color: var(--admin-border);
+    --pico-muted-background-color: var(--admin-surface-muted);
+    --pico-border-color: var(--admin-border);
+    --pico-success: var(--admin-success);
+    --pico-danger: var(--admin-error);
+}
+
+body {
+    background-color: var(--admin-bg);
+    color: var(--admin-text);
+}
+
+a {
+    color: var(--admin-link);
+    transition: color 0.2s ease;
+}
+
+a:hover,
+a:focus-visible {
+    color: var(--admin-link-hover);
+}
+
+.admin-accent {
+    color: var(--admin-primary);
+}
+
+.admin-error-text {
+    color: var(--admin-error);
+}
+
+.admin-success-text {
+    color: var(--admin-success);
+}
+
+.admin-info-text {
+    color: var(--admin-info);
+}
+
+.admin-required {
+    color: var(--admin-error);
+}
+
+body.dark-mode {
+    color-scheme: dark;
+    --admin-bg: #0f172a;
+    --admin-surface: #1e293b;
+    --admin-surface-muted: #1b2538;
+    --admin-surface-subtle: #243044;
+    --admin-border: rgba(148, 163, 184, 0.28);
+    --admin-border-strong: rgba(148, 163, 184, 0.4);
+    --admin-text: #e2e8f0;
+    --admin-text-muted: #94a3b8;
+    --admin-heading: #f8fafc;
+    --admin-inverse-text: #0b1220;
+    --admin-link: #93c5fd;
+    --admin-link-hover: #bfdbfe;
+    --admin-primary: #60a5fa;
+    --admin-primary-hover: #3b82f6;
+    --admin-primary-soft: rgba(96, 165, 250, 0.22);
+    --admin-primary-contrast: #07142b;
+    --admin-success: #4ade80;
+    --admin-success-hover: #22c55e;
+    --admin-error: #f87171;
+    --admin-info: #93c5fd;
+    --admin-header-gradient-start: #1e3a8a;
+    --admin-header-gradient-end: #1d4ed8;
+    --admin-header-overlay: rgba(8, 11, 24, 0.55);
+    --admin-header-shadow: 0 10px 40px rgba(3, 7, 18, 0.7);
+    --admin-header-text-color: #f8fafc;
+    --admin-header-link-color: #dbeafe;
+    --admin-nav-chip-bg: rgba(148, 163, 184, 0.16);
+    --admin-nav-chip-border: rgba(148, 163, 184, 0.3);
+    --admin-nav-chip-hover-bg: rgba(148, 163, 184, 0.28);
+    --admin-nav-chip-hover-shadow: 0 8px 25px rgba(3, 7, 18, 0.65);
+    --admin-flag-border: rgba(148, 163, 184, 0.5);
+    --admin-flag-current-border: rgba(224, 242, 254, 0.85);
+    --admin-flag-shadow: 0 2px 8px rgba(2, 6, 23, 0.5);
+    --admin-table-header-bg: rgba(96, 165, 250, 0.16);
+    --admin-table-header-text: #e2e8f0;
+    --admin-table-row-bg: rgba(15, 23, 42, 0.7);
+    --admin-table-row-alt-bg: rgba(96, 165, 250, 0.12);
+    --admin-table-border: rgba(148, 163, 184, 0.25);
+    --admin-pagination-border: var(--admin-primary);
+    --admin-pagination-text: var(--admin-link);
+    --admin-pagination-hover-bg: var(--admin-primary);
+    --admin-pagination-hover-color: var(--admin-primary-contrast);
+    --admin-overlay-background: rgba(2, 6, 23, 0.88);
+    --admin-overlay-text: #f8fafc;
+    --admin-overlay-shadow: 0 0 20px rgba(2, 6, 23, 0.7);
+    --admin-card-shadow: 0 2px 20px rgba(2, 6, 23, 0.6);
+    --admin-map-card-bg: rgba(15, 23, 42, 0.9);
+    --admin-map-card-shadow: 0 8px 30px rgba(3, 7, 18, 0.65);
+    --admin-map-caption-bg: rgba(15, 23, 42, 0.65);
+    --admin-map-outline: rgba(148, 197, 253, 0.9);
+    --admin-heading-gradient-start: #c7d2fe;
+    --admin-heading-gradient-end: #bfdbfe;
+    --admin-heading-shadow: 0 2px 16px rgba(2, 6, 23, 0.45);
+
+    --pico-background-color: var(--admin-bg);
+    --pico-color: var(--admin-text);
+    --pico-primary: var(--admin-primary);
+    --pico-primary-inverse: var(--admin-primary-contrast);
+    --pico-primary-background: var(--admin-primary);
+    --pico-primary-hover-background: var(--admin-primary-hover);
+    --pico-card-background-color: var(--admin-surface);
+    --pico-form-element-background-color: var(--admin-surface-muted);
+    --pico-muted-color: var(--admin-text-muted);
+    --pico-muted-border-color: var(--admin-border);
+    --pico-muted-background-color: var(--admin-surface-muted);
+    --pico-border-color: var(--admin-border);
+    --pico-success: var(--admin-success);
+    --pico-danger: var(--admin-error);
+}

--- a/admin/edit.php
+++ b/admin/edit.php
@@ -7,12 +7,14 @@
     <title>Admin - PraceAR - Editar Datos Generales de Puesto - Página de administración</title>
      <style>
         <?php
+            require_once(CSS_ADMIN . 'theme.css');
             require_once(CSS_ADMIN . 'header.css');
             require_once(CSS_ADMIN . 'edit_admin.css');
         ?>
     </style>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <link rel='icon' href='./img/favicon.png' type='image/png'>
+    <link rel="stylesheet" href="./css/darkmode.css">
 
     <!-- Iconos para dispositivos Apple -->
     <link rel="apple-touch-icon" sizes="180x180" href="./img/apple-touch-icon-180x180.png">
@@ -66,10 +68,10 @@
         aria-labelledby="cabecera-tabla">
         <input type="hidden" name="csrf" value="<?= isset($_SESSION['csrf']) ? $_SESSION['csrf'] : '' ?>">
         <h2 id="cabecera-tabla" style="text-align: center;">Datos del puesto <span
-                style="color: #1e7dbd"><?= htmlspecialchars($fila["nombre"]) ?></span>
+                class="admin-accent"><?= htmlspecialchars($fila["nombre"]) ?></span>
         </h2>
         <div style="display:flex; align-items: center; gap: .5em;">
-            <label for="activo">Activo <span style="color: red;">*</span></label>
+            <label for="activo">Activo <span class="admin-required" aria-hidden="true">*</span></label>
             <?php
             $activo = $fila["activo"];
             ?>
@@ -103,8 +105,8 @@
                     <img src="<?= htmlspecialchars($ruta_a_imagen) ?>"
                         alt="Imagen del puesto <?= htmlspecialchars($fila["nombre"]) ?>" class="zoomable"
                         style="object-fit: cover; height: 300px; width: 300px; display: block; margin: 0 auto;">
-                    <a href="#" id="eliminar-imagen-link"
-                        style="margin-top: 1em; color: red; text-decoration: none; text-align: center; display: block;"
+                    <a href="#" id="eliminar-imagen-link" class="admin-error-text"
+                        style="margin-top: 1em; text-decoration: none; text-align: center; display: block;"
                         aria-label="Eliminar imagen">Eliminar</a>
                     <script>
                         document.getElementById('eliminar-imagen-link').addEventListener('click', function (event) {
@@ -136,7 +138,7 @@
                 placeholder="Teléfono de contacto. Por ejemplo: '981 123 456'" aria-label="Teléfono de contacto">
         </div>
         <div>
-            <label for="tipo-unity">Tipo en Unity <span style="color: red;">*</span></label>
+            <label for="tipo-unity">Tipo en Unity <span class="admin-required" aria-hidden="true">*</span></label>
             <select name="tipo_unity" id="tipo-unity" aria-required="true">
                 <?php foreach (UNITY_TYPE as $key => $value) { ?>
                     <option value="<?= $key ?>" <?= $fila["tipo_unity"] == $key ? "selected" : "" ?>>
@@ -145,7 +147,7 @@
             </select>
         </div>
         <div>
-            <label for="id-nave">ID Nave <span style="color: red;">*</span></label>
+            <label for="id-nave">ID Nave <span class="admin-required" aria-hidden="true">*</span></label>
             <select required id="id-nave" name="id_nave" aria-required="true">
                 <?php
                 $sql_naves = "SELECT * FROM naves";
@@ -168,7 +170,7 @@
         </div>
     </form>
 
-    <p class="note" style="color: red; text-align: center;">Los campos marcados con <span style="color: red;">*</span>
+    <p class="note admin-error-text" style="text-align: center;">Los campos marcados con <span class="admin-required" aria-hidden="true">*</span>
         son
         obligatorios</p>
 

--- a/admin/edit_translations.php
+++ b/admin/edit_translations.php
@@ -7,15 +7,18 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Admin - PraceAR - Editar Traducciones de Puesto - Página de administración</title>
         <style>
-         <?php require_once(CSS_ADMIN . 'header.css'); ?>
+        <?php
+            require_once(CSS_ADMIN . 'theme.css');
+            require_once(CSS_ADMIN . 'header.css');
+        ?>
         /* Máximo tamaño del body */
         body {
             max-width: 90vw;
             margin: 0 auto;
             padding: 1em;
             font-family: Arial, sans-serif;
-            background-color: #f4f4f4;
-            color: #333;
+            background-color: var(--admin-bg);
+            color: var(--admin-text);
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -28,9 +31,10 @@
             max-width: 600px;
             margin: 2em auto 0 auto;
             padding: 1.5em;
-            background-color: #fff;
+            background-color: var(--admin-surface);
             border-radius: 8px;
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.08);
+            box-shadow: var(--admin-card-shadow);
+            border: 1px solid var(--admin-border);
             display: flex;
             flex-direction: column;
             gap: 1em;
@@ -40,22 +44,33 @@
             display: block;
             margin-bottom: 0.5em;
             font-weight: bold;
+            color: var(--admin-text-muted);
         }
 
         input[type="text"], textarea {
             width: 100%;
             padding: 0.5em;
             margin-bottom: 1em;
-            border: 1px solid #ccc;
-            border-radius: 3px;
+            border: 1px solid var(--admin-border);
+            border-radius: 6px;
             box-sizing: border-box;
             font-size: 1em;
+            background-color: var(--admin-surface-muted);
+            color: var(--admin-text);
+        }
+
+        input[type="text"]:focus,
+        textarea:focus {
+            outline: none;
+            border-color: var(--admin-primary);
+            box-shadow: 0 0 0 3px var(--admin-primary-soft);
         }
 
         h2 {
             text-align: center;
             margin-top: 1.5em;
             margin-bottom: 1em;
+            color: var(--admin-heading);
         }
 
         p[style] {
@@ -64,28 +79,29 @@
 
         @media (max-width: 700px) {
             body {
-            max-width: 100vw;
-            padding: 0.5em;
+                max-width: 100vw;
+                padding: 0.5em;
             }
             form {
-            max-width: 100%;
-            padding: 1em;
+                max-width: 100%;
+                padding: 1em;
             }
             h2 {
-            font-size: 1.2em;
+                font-size: 1.2em;
             }
         }
 
         @media (max-width: 480px) {
             form {
-            padding: 0.5em;
+                padding: 0.5em;
             }
             input[type="text"], textarea {
-            font-size: 0.95em;
+                font-size: 0.95em;
             }
         }
-        
+
     </style>
+    <link rel="stylesheet" href="./css/darkmode.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <link rel='icon' href='./img/favicon.png' type='image/png'>
 
@@ -159,7 +175,7 @@
 
     ?>
 
-    <h2 style="text-align: center;">Traducción del puesto<span style="color: #1e7dbd;">
+    <h2 style="text-align: center;">Traducción del puesto<span class="admin-accent">
             <?php
             // Obtener el nombre del puesto
             $sql_nombre_puesto = "SELECT nombre FROM puestos WHERE id = ?";
@@ -183,7 +199,7 @@
 
     <form class="pure-form" action="#" method="POST" id="formulario" aria-labelledby="formulario-titulo">
         <input type="hidden" name="csrf" value="<?= isset($_SESSION['csrf']) ? $_SESSION['csrf'] : '' ?>">
-        <label for="tipo">Tipo <span style="color: red;" aria-hidden="true">*</span></label>
+        <label for="tipo">Tipo <span class="admin-required" aria-hidden="true">*</span></label>
         <input type="text" id="tipo" name="tipo" value="<?= htmlspecialchars($data['tipo'] ?? "") ?>"
             placeholder="Tipo de puesto. Por ejemplo: 'Bisutería'" required aria-required="true"
             aria-describedby="tipo-descripcion">
@@ -199,7 +215,7 @@
         <input type="hidden" name="id_traduccion" value="<?= htmlspecialchars($data['id'] ?? "") ?>">
         <input type="submit" value="Actualizar">
     </form>
-    <p style="color: red; text-align: center;">Los campos marcados con <span style="color: red;"
+    <p class="admin-error-text" style="text-align: center;">Los campos marcados con <span class="admin-required"
             aria-hidden="true">*</span> son
         obligatorios</p>
     <?= htmlspecialchars($mensaje ?? ""); ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin - PraceAR - Página Principal del Panel de Administración</title>
     <style>
+        <?php require_once(CSS_ADMIN . 'theme.css'); ?>
         <?php require_once(CSS_ADMIN . 'header.css'); ?>
         <?php require_once(CSS_ADMIN . 'index_admin.css'); ?>
     </style>

--- a/admin/js/check_password_requirements.js
+++ b/admin/js/check_password_requirements.js
@@ -26,7 +26,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const inputNombreUsuario = getUsernameInput();
     function crearMensajeError(texto) {
         const spanError = document.createElement("span");
-        spanError.style.color = "red";
+        spanError.classList.add("admin-error-text");
         spanError.textContent = texto;
         inputNuevaContrasena.insertAdjacentElement("afterend", spanError);
     }
@@ -37,7 +37,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     window.checkPasswordRequirements = async () => {
         const nuevaContrasena = inputNuevaContrasena.value;
-        const mensajesError = formulario.querySelectorAll('span[style="color: red;"]');
+        const mensajesError = formulario.querySelectorAll('.admin-error-text');
         mensajesError.forEach((mensaje) => mensaje.remove());
         if (!verifyStrongPassword(nuevaContrasena)) {
             crearMensajeError("La nueva contraseña no cumple con los requisitos de seguridad. Debe tener al menos 16 caracteres, una letra mayúscula, una letra minúscula, un número y tres caracteres especiales distintos.");

--- a/admin/js/edit_stall.js
+++ b/admin/js/edit_stall.js
@@ -190,7 +190,7 @@ formulario.addEventListener("submit", async (event) => {
         alert(errores[0]);
         const div = document.createElement("div");
         div.classList.add("form-errors");
-        div.innerHTML = `<ul style="color: red;">${errores.map((mensaje) => `<li>${mensaje}</li>`).join("")}</ul>`;
+        div.innerHTML = `<ul class="admin-error-text">${errores.map((mensaje) => `<li>${mensaje}</li>`).join("")}</ul>`;
         formulario.insertAdjacentElement("afterend", div);
         return;
     }

--- a/admin/js/edit_translations.js
+++ b/admin/js/edit_translations.js
@@ -43,7 +43,7 @@ formulario.addEventListener("submit", (event) => {
     if (errorExist) {
         event.preventDefault();
         const div = document.createElement("div");
-        div.innerHTML = `<ul style="color: red;">${errorMessages}</ul>`;
+        div.innerHTML = `<ul class="admin-error-text">${errorMessages}</ul>`;
         formulario.insertAdjacentElement("afterend", div);
     }
 });

--- a/admin/market_sections.php
+++ b/admin/market_sections.php
@@ -14,9 +14,13 @@
     <link rel="manifest" href="/manifest.json">
 
     <style>
-        <?php require_once(CSS_ADMIN . 'header.css'); ?>
+        <?php
+            require_once(CSS_ADMIN . 'theme.css');
+            require_once(CSS_ADMIN . 'header.css');
+            require_once(CSS_ADMIN . 'market_sections.php');
+        ?>
     </style>
-    <?php require_once(CSS_ADMIN . 'market_sections.php'); ?>
+    <link rel="stylesheet" href="./css/darkmode.css">
 </head>
 
 <body>

--- a/admin/password_generator.php
+++ b/admin/password_generator.php
@@ -120,33 +120,33 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
             $length_range = limpiar_input($_POST['length_range']);
 
             if (!is_numeric($length) || !ctype_digit($length)) {
-                $result = '<span style="color: red; text-align: center;">La longitud debe ser un número natural válido.</span>';
+                $result = '<span class="admin-error-text" style="text-align: center;">La longitud debe ser un número natural válido.</span>';
             } else {
                 $length = (int) $length;
                 $length_range = (int) $length_range;
 
                 if ($length < 16 || $length > 500 || $length_range < 16 || $length_range > 500) {
-                    $result = '<span style="color: red; text-align: center;">La longitud debe estar entre 16 y 500 caracteres.</span>';
+                    $result = '<span class="admin-error-text" style="text-align: center;">La longitud debe estar entre 16 y 500 caracteres.</span>';
                 } elseif ($length !== $length_range) {
-                    $result = '<span style="color: red; text-align: center;">No se permite modificar el código Javascript que sincroniza los inputs.</span>';
+                    $result = '<span class="admin-error-text" style="text-align: center;">No se permite modificar el código Javascript que sincroniza los inputs.</span>';
                 } else {
                     try {
                         for ($i = 0; $i < $quantity; $i++) { // $quantity siempre será 1
                             $passwords[] = generate_password($length);
                         }
 
-                        $result = '<div id="contrasenas-generadas" style="color: #1e90ff; text-align: center; font-size: 1.2rem;">';
+                        $result = '<div id="contrasenas-generadas">';
                         foreach ($passwords as $index => $password) {
                             $passwordId = "password-$index";
-                            $result .= '<div style="font-size: 1.8rem; color: black;">Contraseña ' . ($index + 1) . ':</div>';
-                            $result .= '<div id="' . $passwordId . '" style="font-size: 1.3rem;">' . htmlspecialchars($password) . '</div>';
+                            $result .= '<div class="password-summary__title">Contraseña ' . ($index + 1) . ':</div>';
+                            $result .= '<div id="' . $passwordId . '" class="password-summary__value">' . htmlspecialchars($password) . '</div>';
                             $result .= '<button onclick="copyToClipboard(\'' . $passwordId . '\')">Copiar</button>';
-                            $result .= '<div style="margin-top: 0.5rem; color: #000080; font-size: 0.75rem;"> Número de mayúsculas: ' . contar_mayusculas($password) . '</div>';
-                            $result .= '<div style="margin-top: 0.5rem; color: #000080; font-size: 0.75rem;"> Número de minúsculas: ' . contar_minusculas($password) . '</div>';
-                            $result .= '<div style="margin-top: 0.5rem; color: #000080; font-size: 0.75rem;"> Número de dígitos: ' . contar_digitos($password) . '</div>';
-                            $result .= '<div style="margin-top: 0.5rem; color: #000080; font-size: 0.75rem;"> Número de caracteres especiales: ' . contar_caracteres_especiales($password) . '</div>';
-                            $result .= '<div style="margin-top: 0.5rem; color: #000080; font-size: 0.75rem;"> Tiempo estimado de resistencia del hash: ' . tiempo_estimado_resistencia_ataque_fuerza_bruta($password) . '</div>';
-                            $result .= '<div style="margin-top: 0.5rem; color: #000080; font-size: 0.75rem;"> Entropía: ' . entropia($password) . '</div>';
+                            $result .= '<div class="password-summary__stat"> Número de mayúsculas: ' . contar_mayusculas($password) . '</div>';
+                            $result .= '<div class="password-summary__stat"> Número de minúsculas: ' . contar_minusculas($password) . '</div>';
+                            $result .= '<div class="password-summary__stat"> Número de dígitos: ' . contar_digitos($password) . '</div>';
+                            $result .= '<div class="password-summary__stat"> Número de caracteres especiales: ' . contar_caracteres_especiales($password) . '</div>';
+                            $result .= '<div class="password-summary__stat"> Tiempo estimado de resistencia del hash: ' . tiempo_estimado_resistencia_ataque_fuerza_bruta($password) . '</div>';
+                            $result .= '<div class="password-summary__stat"> Entropía: ' . entropia($password) . '</div>';
                             $result .= '<div style="margin-top: 0.5rem;">';
                         }
                         $result .= '</div>';
@@ -161,7 +161,7 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
                         <?php
                         $mostrar_boton = true;
                     } catch (Exception $e) {
-                        $result = '<span style="color: red; text-align: center;">' . $e->getMessage() . '</span>';
+                        $result = '<span class="admin-error-text" style="text-align: center;">' . $e->getMessage() . '</span>';
                     }
                 }
             }
@@ -178,46 +178,105 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin - PraceAR - Generador de Contraseñas</title>
      <style>
-        <?php require_once(CSS_ADMIN . 'header.css'); ?>
+        <?php
+            require_once(CSS_ADMIN . 'theme.css');
+            require_once(CSS_ADMIN . 'header.css');
+        ?>
     </style>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <link rel="icon" href="./img/favicon.png" type="image/png">
+    <link rel="stylesheet" href="./css/darkmode.css">
     <style>
-        .required {
-            color: red;
+        body {
+            background-color: var(--admin-bg);
+            color: var(--admin-text);
         }
 
-        #parrafo-campos-obligatorios {
-            color: red;
+        h1 {
             text-align: center;
+            color: var(--admin-heading);
+            margin-bottom: 1rem;
         }
 
-        /* Estilos responsive para el formulario */
-        @media (max-width: 600px) {
-            form {
-                width: 90%;
-                margin: 0 auto;
-            }
+        #password-text-container {
+            text-align: center;
+            margin-bottom: 1rem;
+        }
 
-            input[type="number"],
-            input[type="range"] {
-                width: 100%;
-            }
-        }   
+        #formulario-generacion-contrasena {
+            max-width: 480px;
+            margin: 0 auto;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            background: var(--admin-surface);
+            border: 1px solid var(--admin-border);
+            border-radius: 12px;
+            padding: 2rem 2.5rem;
+            box-shadow: var(--admin-card-shadow);
+        }
+
+        #formulario-generacion-contrasena label {
+            font-weight: 600;
+            color: var(--admin-text-muted);
+        }
+
+        #formulario-generacion-contrasena input[type="number"],
+        #formulario-generacion-contrasena input[type="range"] {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            border-radius: 8px;
+            border: 1px solid var(--admin-border);
+            background: var(--admin-surface-muted);
+            color: var(--admin-text);
+        }
+
+        #formulario-generacion-contrasena input[type="number"]:focus,
+        #formulario-generacion-contrasena input[type="range"]:focus {
+            outline: none;
+            border-color: var(--admin-primary);
+            box-shadow: 0 0 0 3px var(--admin-primary-soft);
+        }
+
+        #formulario-generacion-contrasena input[type="submit"] {
+            width: 100%;
+            padding: 0.9rem 0;
+            border-radius: 8px;
+            background: var(--admin-primary);
+            color: var(--admin-primary-contrast);
+            border: none;
+            cursor: pointer;
+            font-weight: 600;
+            transition: background-color 0.2s ease, transform 0.2s ease;
+        }
+
+        #formulario-generacion-contrasena input[type="submit"]:hover {
+            background: var(--admin-primary-hover);
+            transform: translateY(-1px);
+        }
+
+        #length-output {
+            display: block;
+            text-align: center;
+            margin-top: -1.5rem;
+            color: var(--admin-info);
+            font-weight: 600;
+        }
 
         button {
             margin-top: 0.5rem;
             padding: 0.5rem 1rem;
             font-size: 1rem;
             cursor: pointer;
-            background-color: #4CAF50;
-            color: white;
+            background-color: var(--admin-success);
+            color: var(--admin-primary-contrast);
             border: none;
-            border-radius: 4px;
+            border-radius: 6px;
+            transition: background-color 0.2s ease;
         }
 
         button:hover {
-            background-color: #45a049;
+            background-color: var(--admin-success-hover);
         }
 
         .sr-only {
@@ -232,14 +291,20 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
         }
 
         #success-message {
-            color: green;
+            color: var(--admin-success);
+            display: block;
+            text-align: center;
+            margin-top: 1rem;
+        }
+
+        .copy-feedback {
             display: block;
             text-align: center;
             margin-top: 1rem;
         }
 
         #resistencia-output {
-            color: blue;
+            color: var(--admin-info);
             text-align: center;
             margin-top: 0.75rem;
             font-size: 1.2rem;
@@ -255,6 +320,56 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
 
         #contrasenas-generadas {
             margin-top: 1rem;
+            text-align: center;
+            color: var(--admin-info);
+            font-size: 1.1rem;
+        }
+
+        .password-summary__title {
+            font-size: 1.8rem;
+            color: var(--admin-heading);
+            margin-top: 0.75rem;
+        }
+
+        .password-summary__stat {
+            margin-top: 0.5rem;
+            color: var(--admin-info);
+            font-size: 0.85rem;
+        }
+
+        .password-summary__value {
+            font-size: 1.3rem;
+            font-weight: 600;
+            color: var(--admin-heading);
+            margin-top: 0.5rem;
+        }
+
+        .form-hint {
+            text-align: center;
+            margin-top: 0.75rem;
+        }
+
+        .password-strength {
+            color: var(--admin-info);
+            text-align: center;
+            margin-top: 0.75rem;
+            font-size: 1.2rem;
+            font-weight: bold;
+            display: block;
+            margin-bottom: 1rem;
+            transition: all 0.3s ease-in-out;
+        }
+
+        @media (max-width: 600px) {
+            #formulario-generacion-contrasena {
+                width: 90%;
+                padding: 1.5rem;
+            }
+
+            input[type="number"],
+            input[type="range"] {
+                width: 100%;
+            }
         }
     </style>
 </head>
@@ -262,36 +377,36 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
 <body>
     <?php require_once COMPONENT_ADMIN . 'sections' . DIRECTORY_SEPARATOR . 'header.php'; ?>
 
-    <h1 style="text-align: center;" tabindex="0">Generador de Contraseñas</h1>
+    <h1 tabindex="0">Generador de Contraseñas</h1>
 
-    <div style="text-align: center; margin-bottom: 1rem;">
+    <div id="password-text-container">
         <span id="password-text"><?= $result ?></span>
     </div>
 
-    <form method="POST" action="#" style="max-width: 400px; margin: 0 auto;" id="formulario-generacion-contrasena"
+    <form method="POST" action="#" id="formulario-generacion-contrasena"
         aria-labelledby="formulario-titulo">
         <input type="hidden" name="csrf" value="<?= $_SESSION['csrf'] ?>">
-        <label for="length-number">Longitud de la Contraseña: <span class="required" aria-hidden="true">*</span></label>
+        <label for="length-number">Longitud de la Contraseña: <span class="admin-required" aria-hidden="true">*</span></label>
         <input required type="number" id="length-number" name="length" min="16" max="500"
             value="<?= htmlspecialchars($length, ENT_QUOTES, 'UTF-8') ?>" oninput="syncInputs('number')"
             aria-describedby="length-help">
         <p id="length-help" class="sr-only">Introduce un número entre 16 y 500.</p>
 
-        <label for="length-range">Longitud de la Contraseña: <span class="required" aria-hidden="true">*</span></label>
+        <label for="length-range">Longitud de la Contraseña: <span class="admin-required" aria-hidden="true">*</span></label>
         <input required type="range" id="length-range" name="length_range" min="16" max="500"
             value="<?= htmlspecialchars($length, ENT_QUOTES, 'UTF-8') ?>" oninput="syncInputs('range')"
             aria-describedby="length-help">
 
-        <output id="length-output" style="display: block; text-align: center; margin-top: -1.5rem;" aria-live="polite">
+        <output id="length-output" aria-live="polite">
             <?= htmlspecialchars($length, ENT_QUOTES, 'UTF-8') ?>
         </output>
 
         <input type="submit" value="Generar Contraseña" aria-label="Generar contraseña">
     </form>
 
-    <div style="text-align: center; color: red; margin-top: .125rem;">
-        <span id="parrafo-campos-obligatorios" aria-live="polite">Los campos marcados con <span
-                class="required">*</span> son obligatorios.</span>
+    <div class="form-hint">
+        <span id="parrafo-campos-obligatorios" class="admin-error-text" aria-live="polite">Los campos marcados con <span
+                class="admin-required" aria-hidden="true">*</span> son obligatorios.</span>
     </div>
 
     <script>
@@ -305,10 +420,7 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
                 const successMessage = document.createElement('span');
                 successMessage.id = 'success-message';
                 successMessage.textContent = 'Contraseña copiada al portapapeles. Se borrará automáticamente en 5 minutos.';
-                successMessage.style.color = 'green';
-                successMessage.style.display = 'block';
-                successMessage.style.textAlign = 'center';
-                successMessage.style.marginTop = '1rem';
+                successMessage.classList.add('admin-success-text', 'copy-feedback');
                 document.getElementById(passwordId).insertAdjacentElement('afterend', successMessage);
 
                 // Set a timer to clear the password after 5 minutes
@@ -318,10 +430,7 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
                         passwordElement.innerText = 'Contraseña borrada por seguridad.';
                         const clearMessage = document.createElement('span');
                         clearMessage.textContent = 'La contraseña ha sido borrada automáticamente.';
-                        clearMessage.style.color = 'red';
-                        clearMessage.style.display = 'block';
-                        clearMessage.style.textAlign = 'center';
-                        clearMessage.style.marginTop = '1rem';
+                        clearMessage.classList.add('admin-error-text', 'copy-feedback');
                         passwordElement.insertAdjacentElement('afterend', clearMessage);
                     }
                 }, 5 * 60 * 1000); // 5 minutes in milliseconds
@@ -382,14 +491,7 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
             // Creamos el elemento de salida para la resistencia y lo añadimos debajo del output de longitud con texto de color adecuado
             let resistenciaOutput = document.getElementById('resistencia-output') || document.createElement('div');
             resistenciaOutput.id = 'resistencia-output';
-            resistenciaOutput.style.color = 'blue';
-            resistenciaOutput.style.textAlign = 'center';
-            resistenciaOutput.style.marginTop = '0.75rem';
-            resistenciaOutput.style.fontSize = '1.2rem';
-            resistenciaOutput.style.fontWeight = 'bold';
-            resistenciaOutput.style.display = 'block';
-            resistenciaOutput.style.marginBottom = '1rem';
-            resistenciaOutput.style.transition = 'all 0.3s ease-in-out';
+            resistenciaOutput.className = 'password-strength';
 
             if (!resistenciaOutput.parentNode) {
                 document.getElementById('length-output').insertAdjacentElement('afterend', resistenciaOutput);
@@ -421,14 +523,7 @@ if ($_SERVER['REQUEST_METHOD'] === "POST") {
                         const longitud = parseInt(document.getElementById('length-number').value);
                         let resistenciaOutput = document.getElementById('resistencia-output') || document.createElement('div');
                         resistenciaOutput.id = 'resistencia-output';
-                        resistenciaOutput.style.color = 'blue';
-                        resistenciaOutput.style.textAlign = 'center';
-                        resistenciaOutput.style.marginTop = '0.75rem';
-                        resistenciaOutput.style.fontSize = '1.2rem';
-                        resistenciaOutput.style.fontWeight = 'bold';
-                        resistenciaOutput.style.display = 'block';
-                        resistenciaOutput.style.marginBottom = '1rem';
-                        resistenciaOutput.style.transition = 'all 0.3s ease-in-out';
+                        resistenciaOutput.className = 'password-strength';
 
                         resistenciaOutput.textContent = calcularResistencia(longitud);
                         contrasenasGeneradas.insertAdjacentElement('afterend', resistenciaOutput);

--- a/admin/ts/check_password_requirements.ts
+++ b/admin/ts/check_password_requirements.ts
@@ -51,7 +51,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     function crearMensajeError(texto: string): void {
         const spanError = document.createElement("span");
-        spanError.style.color = "red";
+        spanError.classList.add("admin-error-text");
         spanError.textContent = texto;
         inputNuevaContrasena.insertAdjacentElement("afterend", spanError);
     }
@@ -68,7 +68,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     window.checkPasswordRequirements = async () => {
         const nuevaContrasena = inputNuevaContrasena.value;
-        const mensajesError = formulario.querySelectorAll<HTMLSpanElement>('span[style="color: red;"]');
+        const mensajesError = formulario.querySelectorAll<HTMLSpanElement>('.admin-error-text');
         mensajesError.forEach((mensaje) => mensaje.remove());
 
         if (!verifyStrongPassword(nuevaContrasena)) {

--- a/admin/ts/edit_stall.ts
+++ b/admin/ts/edit_stall.ts
@@ -245,7 +245,7 @@ formulario.addEventListener("submit", async (event: SubmitEvent) => {
 
         const div = document.createElement("div");
         div.classList.add("form-errors");
-        div.innerHTML = `<ul style="color: red;">${errores.map((mensaje) => `<li>${mensaje}</li>`).join("")}</ul>`;
+        div.innerHTML = `<ul class="admin-error-text">${errores.map((mensaje) => `<li>${mensaje}</li>`).join("")}</ul>`;
         formulario.insertAdjacentElement("afterend", div);
         return;
     }

--- a/admin/ts/edit_translations.ts
+++ b/admin/ts/edit_translations.ts
@@ -58,7 +58,7 @@ formulario.addEventListener("submit", (event: SubmitEvent) => {
     if (errorExist) {
         event.preventDefault();
         const div = document.createElement("div");
-        div.innerHTML = `<ul style="color: red;">${errorMessages}</ul>`;
+        div.innerHTML = `<ul class="admin-error-text">${errorMessages}</ul>`;
         formulario.insertAdjacentElement("afterend", div);
     }
 });

--- a/css/darkmode.css
+++ b/css/darkmode.css
@@ -1,14 +1,14 @@
 body.dark-mode {
-    background: #181a1b !important;
-    color: #e0e0e0 !important;
+    background: var(--admin-bg, #181a1b) !important;
+    color: var(--admin-text, #e0e0e0) !important;
 }
 
 body.dark-mode input,
 body.dark-mode textarea,
 body.dark-mode select {
-    background: #23272a !important;
-    color: #e0e0e0 !important;
-    border-color: #444 !important;
+    background: var(--admin-surface, #23272a) !important;
+    color: var(--admin-text, #e0e0e0) !important;
+    border-color: var(--admin-border, #444) !important;
 }
 
 body.dark-mode table,
@@ -20,27 +20,27 @@ body.dark-mode main,
 body.dark-mode .zoomed-container,
 body.dark-mode .maps-grid,
 body.dark-mode .note {
-    background: #23272a !important;
-    color: #e0e0e0 !important;
-    border-color: #444 !important;
+    background: var(--admin-surface, #23272a) !important;
+    color: var(--admin-text, #e0e0e0) !important;
+    border-color: var(--admin-border, #444) !important;
 }
 
 body.dark-mode a {
-    color: #8ab4f8 !important;
+    color: var(--admin-link, #8ab4f8) !important;
 }
 
 body.dark-mode .note {
-    color: #ffb4b4 !important;
+    color: var(--admin-error, #ffb4b4) !important;
 }
 
 body.dark-mode .success-message {
-    color: #7fff7f !important;
+    color: var(--admin-success, #7fff7f) !important;
 }
 
 body.dark-mode .error-message {
-    color: #ff7f7f !important;
+    color: var(--admin-error, #ff7f7f) !important;
 }
 
 body.dark-mode img {
-    filter: brightness(0.85) contrast(1.1);
+    filter: brightness(0.95) contrast(1.05);
 }


### PR DESCRIPTION
## Summary
- Introduced a shared admin theme file with light/dark palette variables and updated existing CSS to consume it
- Updated admin pages to load the new theme, link the shared darkmode stylesheet, and replace inline colors with reusable classes
- Adjusted helper scripts to use semantic error/info classes so feedback styling also adapts to dark mode

## Testing
- php -l admin/edit.php
- php -l admin/edit_translations.php
- php -l admin/change_password.php
- php -l admin/password_generator.php
- php -l admin/market_sections.php

------
https://chatgpt.com/codex/tasks/task_e_68e14d33cb8c8325a735c67ab5dea1a0