### PR TITLE
Add modal editing to admin index table

### DIFF
--- a/admin/css/index_admin.css
+++ b/admin/css/index_admin.css
@@ -272,6 +272,141 @@ input::placeholder {
     /* font-size: 0.em; */
 }
 
+.admin-clickable {
+    cursor: pointer;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin-clickable:focus-visible {
+    outline: 2px solid var(--admin-primary);
+    outline-offset: 2px;
+}
+
+.admin-clickable-general:hover,
+.admin-clickable-general:focus-visible {
+    background-color: var(--admin-surface-subtle);
+}
+
+.admin-clickable[data-edit-target="translation"]:hover,
+.admin-clickable[data-edit-target="translation"]:focus-visible {
+    background-color: rgba(30, 125, 189, 0.12);
+}
+
+body.admin-modal-open {
+    overflow: hidden;
+}
+
+.admin-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    background-color: var(--admin-overlay-background);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+    z-index: 10000;
+    pointer-events: none;
+}
+
+.admin-modal.is-visible {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
+.admin-modal__dialog {
+    position: relative;
+    width: min(900px, 95vw);
+    max-height: 90vh;
+    background-color: var(--admin-surface);
+    border-radius: 18px;
+    box-shadow: var(--admin-overlay-shadow);
+    padding: 1.75rem 1.75rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    overflow: hidden;
+}
+
+.admin-modal__close {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    background: none;
+    border: none;
+    font-size: 2.25rem;
+    line-height: 1;
+    color: var(--admin-text);
+    cursor: pointer;
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.admin-modal__close:hover,
+.admin-modal__close:focus-visible {
+    color: var(--admin-primary);
+    transform: scale(1.05);
+}
+
+.admin-modal__title {
+    margin: 0 2rem 0 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--admin-heading);
+}
+
+.admin-modal__frame {
+    flex: 1;
+    border: 0;
+    width: 100%;
+    height: 70vh;
+    border-radius: 12px;
+    background-color: var(--admin-surface-muted);
+    transition: opacity 0.2s ease;
+    opacity: 1;
+}
+
+.admin-modal__frame.is-loading {
+    opacity: 0;
+}
+
+.admin-modal__loader {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(15, 23, 42, 0.08);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.admin-modal__loader.is-active {
+    opacity: 1;
+}
+
+.admin-modal__spinner {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+    border: 4px solid rgba(255, 255, 255, 0.4);
+    border-top-color: var(--admin-primary);
+    animation: admin-modal-spin 0.9s linear infinite;
+}
+
+@keyframes admin-modal-spin {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
 @media (max-width: 600px) {
     table {
         border: 0;
@@ -363,5 +498,30 @@ input::placeholder {
     #imagen-boton-cierre-sesion {
         max-width: 40px;
         max-height: 40px;
+    }
+
+    .admin-modal {
+        padding: 1.25rem;
+    }
+
+    .admin-modal__dialog {
+        width: 100%;
+        max-height: 95vh;
+        padding: 1.5rem 1rem 1rem;
+        border-radius: 14px;
+    }
+
+    .admin-modal__title {
+        font-size: 1.25rem;
+    }
+
+    .admin-modal__frame {
+        height: 60vh;
+        border-radius: 10px;
+    }
+
+    .admin-modal__close {
+        font-size: 1.8rem;
+        right: 0.5rem;
     }
 }

--- a/admin/index.php
+++ b/admin/index.php
@@ -156,7 +156,9 @@
                 </thead>
                 <tbody>
                     <?php while ($row = $result->fetch_assoc()): ?>
-                        <tr id="row-<?= htmlspecialchars($row['id']) ?>">
+                        <tr id="row-<?= htmlspecialchars($row['id']) ?>"
+                            data-edit-url="<?= htmlspecialchars('?page=edit&id=' . $row['id'] . '&lang=' . ($_REQUEST['lang'] ?? 'gl')) ?>"
+                            data-translation-url="<?= htmlspecialchars('?page=language&codigo_idioma=' . get_language() . '&id=' . $row['id'] . '&lang=' . ($_REQUEST['lang'] ?? 'gl')) ?>">
                             <td scope="row" data-label="Editar">
                                 <a href="<?= "?page=edit&id=" . htmlspecialchars($row['id']) . "&lang=" . htmlspecialchars($_REQUEST['lang'] ?? 'gl') ?>"
                                     aria-label="Editar puesto <?= htmlspecialchars($row['caseta']) ?>">
@@ -164,7 +166,8 @@
                                         alt="Editar">
                                 </a>
                             </td>
-                            <td data-label="Activo">
+                            <td data-label="Activo" class="admin-clickable admin-clickable-general" tabindex="0"
+                                data-edit-target="general">
                                 <?= htmlspecialchars($row['activo'] ? "Sí" : "No") ?>
                             </td>
                             <td data-label="Imagen">
@@ -175,24 +178,35 @@
                                         alt="Imagen del puesto <?= htmlspecialchars($row['caseta']) ?>">
                                 <?php endif; ?>
                             </td>
-                            <td data-label="Caseta"><?= htmlspecialchars($row['caseta']) ?></td>
-                            <td data-label="Nombre"><?= htmlspecialchars($row['nombre']) ?></td>
-                            <td data-label="Tipo Unity"><?= htmlspecialchars($row['tipo_unity']) ?></td>
-                            <td data-label="Información de Contacto"><?= htmlspecialchars($row['contacto']) ?></td>
-                            <td data-label="Teléfono"><?= htmlspecialchars($row['telefono']) ?></td>
-                            <td data-label="Nave"><?= htmlspecialchars($row['nave']) ?></td>
-                            <td data-label="Caseta padre"><?= htmlspecialchars($row["caseta_padre"] ?? "Ninguno") ?></td>
+                            <td data-label="Caseta" class="admin-clickable admin-clickable-general" tabindex="0"
+                                data-edit-target="general"><?= htmlspecialchars($row['caseta']) ?></td>
+                            <td data-label="Nombre" class="admin-clickable admin-clickable-general" tabindex="0"
+                                data-edit-target="general"><?= htmlspecialchars($row['nombre']) ?></td>
+                            <td data-label="Tipo Unity" class="admin-clickable admin-clickable-general" tabindex="0"
+                                data-edit-target="general"><?= htmlspecialchars($row['tipo_unity']) ?></td>
+                            <td data-label="Información de Contacto" class="admin-clickable admin-clickable-general"
+                                tabindex="0" data-edit-target="general"><?= htmlspecialchars($row['contacto']) ?></td>
+                            <td data-label="Teléfono" class="admin-clickable admin-clickable-general" tabindex="0"
+                                data-edit-target="general"><?= htmlspecialchars($row['telefono']) ?></td>
+                            <td data-label="Nave" class="admin-clickable admin-clickable-general" tabindex="0"
+                                data-edit-target="general"><?= htmlspecialchars($row['nave']) ?></td>
+                            <td data-label="Caseta padre" class="admin-clickable admin-clickable-general" tabindex="0"
+                                data-edit-target="general"><?= htmlspecialchars($row["caseta_padre"] ?? "Ninguno") ?></td>
                             <td data-label="" class="celda-especial-dato"></td>
-                            <td data-label="Idioma de la traducción" class="fondo-color-diferente">
+                            <td data-label="Idioma de la traducción" class="fondo-color-diferente admin-clickable"
+                                tabindex="0" data-edit-target="translation">
                                 <a href="<?= "?page=language&codigo_idioma=" . htmlspecialchars(get_language()) . "&id=" . htmlspecialchars($row['id']) . "&lang=" . htmlspecialchars($_REQUEST['lang'] ?? 'gl') ?>"
-                                    aria-label="Editar traducción del puesto <?= htmlspecialchars($row['caseta']) ?>">
+                                    aria-label="Editar traducción del puesto <?= htmlspecialchars($row['caseta']) ?>"
+                                    data-translation-link="true">
                                     <img class="imagen-bandera" loading="lazy" width="15" height="15"
                                         src="<?= htmlspecialchars(FLAG_IMAGES_URL . (get_language()) . ".png") ?>"
                                         alt="Idioma <?= htmlspecialchars(get_language()) ?>">
                                 </a>
                             </td>
-                            <td data-label="Tipo" class="fondo-color-diferente"><?= htmlspecialchars($row['tipo']) ?></td>
-                            <td data-label="Descripción" class="fondo-color-diferente">
+                            <td data-label="Tipo" class="fondo-color-diferente admin-clickable" tabindex="0"
+                                data-edit-target="translation"><?= htmlspecialchars($row['tipo']) ?></td>
+                            <td data-label="Descripción" class="fondo-color-diferente admin-clickable" tabindex="0"
+                                data-edit-target="translation">
                                 <?= htmlspecialchars($row['descripcion'] ? truncate_text($row['descripcion'], 30) : '') ?>
                             </td>
                         </tr>
@@ -214,6 +228,22 @@
         <button class="close-button" aria-label="Cerrar vista ampliada">&times;</button>
         <img id="zoomed-image" src="" alt="Imagen ampliada del puesto">
         <p id="zoomed-name"></p>
+    </div>
+
+    <div id="admin-modal" class="admin-modal" role="dialog" aria-modal="true" aria-hidden="true"
+        aria-labelledby="admin-modal-title">
+        <div class="admin-modal__dialog" role="document">
+            <button type="button" class="admin-modal__close" data-modal-close aria-label="Cerrar ventana de edición">
+                &times;
+            </button>
+            <h2 id="admin-modal-title" class="admin-modal__title">Editar puesto</h2>
+            <div class="admin-modal__loader" data-modal-loader role="status" aria-live="polite"
+                aria-label="Cargando contenido">
+                <span class="admin-modal__spinner" aria-hidden="true"></span>
+            </div>
+            <iframe id="admin-modal-frame" title="Formulario de edición" loading="lazy"
+                class="admin-modal__frame" tabindex="-1"></iframe>
+        </div>
     </div>
 
     <script>

--- a/admin/js/index.js
+++ b/admin/js/index.js
@@ -33,4 +33,116 @@ window.addEventListener("load", () => {
         styles.forEach(style => style.remove());
     }
 });
+
+const modal = document.getElementById("admin-modal");
+const modalFrame = document.getElementById("admin-modal-frame");
+const modalCloseButton = modal?.querySelector("[data-modal-close]");
+const modalLoader = modal?.querySelector("[data-modal-loader]");
+const modalTitle = document.getElementById("admin-modal-title");
+
+if (modal instanceof HTMLElement && modalFrame instanceof HTMLIFrameElement && modalCloseButton instanceof HTMLButtonElement && modalLoader instanceof HTMLElement && modalTitle instanceof HTMLElement) {
+    let lastFocusedElement = null;
+
+    const setLoaderState = (isActive) => {
+        modalLoader.classList.toggle("is-active", isActive);
+        modalFrame.classList.toggle("is-loading", isActive);
+    };
+
+    const closeModal = () => {
+        modal.classList.remove("is-visible");
+        modal.setAttribute("aria-hidden", "true");
+        document.body.classList.remove("admin-modal-open");
+        modalFrame.src = "about:blank";
+        setLoaderState(false);
+        if (lastFocusedElement instanceof HTMLElement) {
+            lastFocusedElement.focus();
+        }
+        lastFocusedElement = null;
+    };
+
+    const openModal = (url, trigger, type) => {
+        if (!url) {
+            return;
+        }
+
+        lastFocusedElement = trigger instanceof HTMLElement ? trigger : null;
+        document.body.classList.add("admin-modal-open");
+        modal.classList.add("is-visible");
+        modal.setAttribute("aria-hidden", "false");
+        modalTitle.textContent = type === "translation" ? "Editar traducción del puesto" : "Editar puesto";
+        setLoaderState(true);
+        modalFrame.src = url;
+        modalCloseButton.focus();
+    };
+
+    modalCloseButton.addEventListener("click", closeModal);
+    modal.addEventListener("click", (event) => {
+        if (event.target === modal) {
+            closeModal();
+        }
+    });
+
+    document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape" && modal.classList.contains("is-visible")) {
+            closeModal();
+        }
+    });
+
+    modalFrame.addEventListener("load", () => {
+        setLoaderState(false);
+        modalFrame.focus();
+    });
+
+    const handleActivation = (element, type) => {
+        const open = (event) => {
+            const target = event.target;
+            if (type === "translation" && target instanceof HTMLElement && target.closest("a[data-translation-link='true']")) {
+                return;
+            }
+
+            event.preventDefault();
+            const row = element.closest("tr");
+            const url = row?.dataset[type === "translation" ? "translationUrl" : "editUrl"];
+            openModal(url, element, type);
+        };
+
+        element.addEventListener("click", open);
+        element.addEventListener("keydown", (event) => {
+            if (event.key === "Enter" || event.key === " ") {
+                open(event);
+            }
+        });
+    };
+
+    document.querySelectorAll('[data-edit-target="general"]').forEach((element) => {
+        if (element instanceof HTMLElement) {
+            handleActivation(element, "general");
+        }
+    });
+
+    document.querySelectorAll('[data-edit-target="translation"]').forEach((element) => {
+        if (element instanceof HTMLElement) {
+            handleActivation(element, "translation");
+        }
+    });
+
+    document.querySelectorAll('a[data-translation-link="true"]').forEach((link) => {
+        if (link instanceof HTMLAnchorElement) {
+            link.addEventListener("click", (event) => {
+                event.preventDefault();
+                const row = link.closest("tr");
+                const url = row?.dataset.translationUrl ?? link.href;
+                openModal(url, link, "translation");
+            });
+            link.addEventListener("keydown", (event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    const row = link.closest("tr");
+                    const url = row?.dataset.translationUrl ?? link.href;
+                    openModal(url, link, "translation");
+                }
+            });
+        }
+    });
+}
 export {};


### PR DESCRIPTION
## Summary
- allow clicking table cells to open the existing edit and translation flows without using the pencil/flag links
- load the edit and translation forms inside a reusable modal with focus and loader handling
- style the index rows and modal overlay to highlight clickable areas and match the admin look and feel

## Testing
- php -l admin/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e5463ccf908325acf4ef848757f2d2