### PR TITLE
feat: enable modal editing from admin index

### DIFF
--- a/admin/css/index_admin.css
+++ b/admin/css/index_admin.css
@@ -74,6 +74,23 @@ table td {
     text-align: center;
 }
 
+.admin-table-cell--editable {
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.admin-table-cell--editable:focus,
+.admin-table-cell--editable:hover {
+    outline: none;
+    background-color: var(--admin-table-row-hover-bg, rgba(0, 0, 0, 0.08));
+    color: var(--admin-text);
+}
+
+.admin-table-cell--editable:focus-visible {
+    outline: 2px solid var(--admin-primary, #2d7ff9);
+    outline-offset: 2px;
+}
+
 table th {
     letter-spacing: .1em;
     text-transform: uppercase;
@@ -151,6 +168,91 @@ table th {
     cursor: pointer;
     background: none;
     border: none;
+}
+
+.admin-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 10000;
+}
+
+.admin-modal.is-open {
+    display: flex;
+}
+
+.admin-modal__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(14, 23, 38, 0.65);
+    backdrop-filter: blur(4px);
+}
+
+.admin-modal__dialog {
+    position: relative;
+    width: min(960px, 90vw);
+    height: min(720px, 90vh);
+    background: var(--admin-surface);
+    border-radius: 16px;
+    box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.45);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid var(--admin-border);
+}
+
+.admin-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.5rem;
+    background: var(--admin-surface-muted, rgba(148, 163, 184, 0.1));
+    border-bottom: 1px solid var(--admin-border);
+    gap: 1rem;
+}
+
+.admin-modal__title {
+    margin: 0;
+    font-size: 1.25rem;
+    color: var(--admin-heading, inherit);
+}
+
+.admin-modal__close {
+    background: none;
+    border: none;
+    color: inherit;
+    font-size: 2rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0;
+    transition: transform 0.2s ease;
+}
+
+.admin-modal__close:hover,
+.admin-modal__close:focus {
+    transform: scale(1.1);
+    outline: none;
+}
+
+.admin-modal__frame {
+    border: 0;
+    flex: 1;
+    width: 100%;
+    background: var(--admin-bg);
+}
+
+@media (max-width: 768px) {
+    .admin-modal__dialog {
+        width: 96vw;
+        height: 92vh;
+        border-radius: 12px;
+    }
+
+    .admin-modal__header {
+        padding: 0.75rem 1rem;
+    }
 }
 
 /* Estilos de paginación */

--- a/admin/index.php
+++ b/admin/index.php
@@ -156,15 +156,22 @@
                 </thead>
                 <tbody>
                     <?php while ($row = $result->fetch_assoc()): ?>
-                        <tr id="row-<?= htmlspecialchars($row['id']) ?>">
+                        <?php
+                        $edit_url = "?page=edit&id=" . htmlspecialchars($row['id']) . "&lang=" . htmlspecialchars($_REQUEST['lang'] ?? 'gl');
+                        $translation_url = "?page=language&codigo_idioma=" . htmlspecialchars(get_language()) . "&id=" . htmlspecialchars($row['id']) . "&lang=" . htmlspecialchars($_REQUEST['lang'] ?? 'gl');
+                        ?>
+                        <tr id="row-<?= htmlspecialchars($row['id']) ?>" data-edit-url="<?= $edit_url ?>"
+                            data-translation-url="<?= $translation_url ?>"
+                            data-caseta="<?= htmlspecialchars($row['caseta']) ?>"
+                            data-nombre="<?= htmlspecialchars($row['nombre']) ?>">
                             <td scope="row" data-label="Editar">
-                                <a href="<?= "?page=edit&id=" . htmlspecialchars($row['id']) . "&lang=" . htmlspecialchars($_REQUEST['lang'] ?? 'gl') ?>"
-                                    aria-label="Editar puesto <?= htmlspecialchars($row['caseta']) ?>">
+                                <a href="<?= $edit_url ?>" aria-label="Editar puesto <?= htmlspecialchars($row['caseta']) ?>">
                                     <img loading="lazy" width='15' height='15' src="<?= htmlspecialchars(PENCIL_IMAGE_URL) ?>"
                                         alt="Editar">
                                 </a>
                             </td>
-                            <td data-label="Activo">
+                            <td data-label="Activo" class="admin-table-cell--editable" data-edit-target="general"
+                                role="button" tabindex="0">
                                 <?= htmlspecialchars($row['activo'] ? "Sí" : "No") ?>
                             </td>
                             <td data-label="Imagen">
@@ -175,24 +182,37 @@
                                         alt="Imagen del puesto <?= htmlspecialchars($row['caseta']) ?>">
                                 <?php endif; ?>
                             </td>
-                            <td data-label="Caseta"><?= htmlspecialchars($row['caseta']) ?></td>
-                            <td data-label="Nombre"><?= htmlspecialchars($row['nombre']) ?></td>
-                            <td data-label="Tipo Unity"><?= htmlspecialchars($row['tipo_unity']) ?></td>
-                            <td data-label="Información de Contacto"><?= htmlspecialchars($row['contacto']) ?></td>
-                            <td data-label="Teléfono"><?= htmlspecialchars($row['telefono']) ?></td>
-                            <td data-label="Nave"><?= htmlspecialchars($row['nave']) ?></td>
-                            <td data-label="Caseta padre"><?= htmlspecialchars($row["caseta_padre"] ?? "Ninguno") ?></td>
+                            <td data-label="Caseta" class="admin-table-cell--editable" data-edit-target="general"
+                                role="button" tabindex="0"><?= htmlspecialchars($row['caseta']) ?></td>
+                            <td data-label="Nombre" class="admin-table-cell--editable" data-edit-target="general"
+                                role="button" tabindex="0"><?= htmlspecialchars($row['nombre']) ?></td>
+                            <td data-label="Tipo Unity" class="admin-table-cell--editable" data-edit-target="general"
+                                role="button" tabindex="0"><?= htmlspecialchars($row['tipo_unity']) ?></td>
+                            <td data-label="Información de Contacto" class="admin-table-cell--editable"
+                                data-edit-target="general" role="button" tabindex="0">
+                                <?= htmlspecialchars($row['contacto']) ?>
+                            </td>
+                            <td data-label="Teléfono" class="admin-table-cell--editable" data-edit-target="general"
+                                role="button" tabindex="0"><?= htmlspecialchars($row['telefono']) ?></td>
+                            <td data-label="Nave" class="admin-table-cell--editable" data-edit-target="general"
+                                role="button" tabindex="0"><?= htmlspecialchars($row['nave']) ?></td>
+                            <td data-label="Caseta padre" class="admin-table-cell--editable" data-edit-target="general"
+                                role="button" tabindex="0"><?= htmlspecialchars($row["caseta_padre"] ?? "Ninguno") ?></td>
                             <td data-label="" class="celda-especial-dato"></td>
-                            <td data-label="Idioma de la traducción" class="fondo-color-diferente">
-                                <a href="<?= "?page=language&codigo_idioma=" . htmlspecialchars(get_language()) . "&id=" . htmlspecialchars($row['id']) . "&lang=" . htmlspecialchars($_REQUEST['lang'] ?? 'gl') ?>"
+                            <td data-label="Idioma de la traducción" class="fondo-color-diferente admin-table-cell--editable"
+                                data-edit-target="translation" role="button" tabindex="0">
+                                <a href="<?= $translation_url ?>"
                                     aria-label="Editar traducción del puesto <?= htmlspecialchars($row['caseta']) ?>">
                                     <img class="imagen-bandera" loading="lazy" width="15" height="15"
                                         src="<?= htmlspecialchars(FLAG_IMAGES_URL . (get_language()) . ".png") ?>"
                                         alt="Idioma <?= htmlspecialchars(get_language()) ?>">
                                 </a>
                             </td>
-                            <td data-label="Tipo" class="fondo-color-diferente"><?= htmlspecialchars($row['tipo']) ?></td>
-                            <td data-label="Descripción" class="fondo-color-diferente">
+                            <td data-label="Tipo" class="fondo-color-diferente admin-table-cell--editable"
+                                data-edit-target="translation" role="button" tabindex="0">
+                                <?= htmlspecialchars($row['tipo']) ?></td>
+                            <td data-label="Descripción" class="fondo-color-diferente admin-table-cell--editable"
+                                data-edit-target="translation" role="button" tabindex="0">
                                 <?= htmlspecialchars($row['descripcion'] ? truncate_text($row['descripcion'], 30) : '') ?>
                             </td>
                         </tr>
@@ -214,6 +234,20 @@
         <button class="close-button" aria-label="Cerrar vista ampliada">&times;</button>
         <img id="zoomed-image" src="" alt="Imagen ampliada del puesto">
         <p id="zoomed-name"></p>
+    </div>
+
+    <div id="admin-modal" class="admin-modal" aria-hidden="true">
+        <div class="admin-modal__overlay" data-close-modal></div>
+        <div class="admin-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="admin-modal-title">
+            <header class="admin-modal__header">
+                <h2 id="admin-modal-title" class="admin-modal__title">Editar contenido</h2>
+                <button type="button" class="admin-modal__close" aria-label="Cerrar ventana" data-close-modal>
+                    &times;
+                </button>
+            </header>
+            <iframe id="admin-modal-frame" title="Editor de administración" class="admin-modal__frame"
+                loading="lazy"></iframe>
+        </div>
     </div>
 
     <script>

--- a/admin/js/index.js
+++ b/admin/js/index.js
@@ -21,7 +21,94 @@ formulario.addEventListener("submit", (event) => {
         alert("Por favor, elimine los caracteres no permitidos, que son: <, >, \", ', %");
     }
 });
-console.log("Código TypeScript de la página de administración de puestos cargado correctamente.");
+const modal = document.getElementById("admin-modal");
+const modalTitle = document.getElementById("admin-modal-title");
+const modalFrame = document.getElementById("admin-modal-frame");
+const closeButtons = Array.from(document.querySelectorAll("[data-close-modal]"));
+let lastFocusedElement = null;
+function openModal(url, title) {
+    if (!(modal instanceof HTMLElement) || !modalFrame || !(modalTitle instanceof HTMLElement)) {
+        window.location.href = url;
+        return;
+    }
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    modal.classList.add("is-open");
+    modal.setAttribute("aria-hidden", "false");
+    document.body.style.overflow = "hidden";
+    modalTitle.textContent = title;
+    modalFrame.src = url;
+    const closeButton = modal.querySelector(".admin-modal__close");
+    closeButton?.focus();
+}
+function closeModal() {
+    if (!(modal instanceof HTMLElement) || !modalFrame) {
+        return;
+    }
+    modal.classList.remove("is-open");
+    modal.setAttribute("aria-hidden", "true");
+    document.body.style.overflow = "";
+    modalFrame.src = "about:blank";
+    if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+    }
+}
+closeButtons.forEach(button => {
+    button.addEventListener("click", () => {
+        closeModal();
+    });
+});
+document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && modal?.classList.contains("is-open")) {
+        event.preventDefault();
+        closeModal();
+    }
+});
+function resolveEditUrl(target, trigger) {
+    const row = trigger.closest("tr[data-edit-url]");
+    if (!row) {
+        return null;
+    }
+    if (target === "translation") {
+        return row.dataset.translationUrl || null;
+    }
+    return row.dataset.editUrl || null;
+}
+function getModalTitle(target, trigger) {
+    const row = trigger.closest("tr[data-edit-url]");
+    const caseta = row?.dataset.caseta;
+    const nombre = row?.dataset.nombre;
+    const baseTitle = target === "translation" ? "Editar traducción" : "Editar puesto";
+    const details = [caseta, nombre].filter(Boolean).join(" · ");
+    return details ? `${baseTitle} · ${details}` : baseTitle;
+}
+function handleModalTrigger(trigger, target) {
+    const url = resolveEditUrl(target, trigger);
+    if (!url) {
+        return;
+    }
+    openModal(url, getModalTitle(target, trigger));
+}
+const editableCells = Array.from(document.querySelectorAll(".admin-table-cell--editable"));
+editableCells.forEach(cell => {
+    const target = cell.dataset.editTarget;
+    if (!target) {
+        return;
+    }
+    cell.addEventListener("click", (event) => {
+        const targetElement = event.target instanceof HTMLElement ? event.target : null;
+        if (targetElement?.closest("a, button")) {
+            return;
+        }
+        handleModalTrigger(cell, target);
+    });
+    cell.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            handleModalTrigger(cell, target);
+        }
+    });
+});
 // Cuando cargue la página, meter todas las etiquetas style en el head en una sola
 window.addEventListener("load", () => {
     const styles = Array.from(document.querySelectorAll("style"));
@@ -33,4 +120,5 @@ window.addEventListener("load", () => {
         styles.forEach(style => style.remove());
     }
 });
+console.log("Código TypeScript de la página de administración de puestos cargado correctamente.");
 export {};

--- a/admin/ts/index.ts
+++ b/admin/ts/index.ts
@@ -30,7 +30,122 @@ formulario.addEventListener("submit", (event: SubmitEvent) => {
     }
 });
 
-console.log("Código TypeScript de la página de administración de puestos cargado correctamente.");
+type EditTarget = "general" | "translation";
+
+const modal = document.getElementById("admin-modal");
+const modalTitle = document.getElementById("admin-modal-title");
+const modalFrame = document.getElementById("admin-modal-frame") as HTMLIFrameElement | null;
+const closeButtons = Array.from(document.querySelectorAll<HTMLElement>("[data-close-modal]"));
+
+let lastFocusedElement: HTMLElement | null = null;
+
+function openModal(url: string, title: string) {
+    if (!(modal instanceof HTMLElement) || !modalFrame || !(modalTitle instanceof HTMLElement)) {
+        window.location.href = url;
+        return;
+    }
+
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    modal.classList.add("is-open");
+    modal.setAttribute("aria-hidden", "false");
+    document.body.style.overflow = "hidden";
+    modalTitle.textContent = title;
+    modalFrame.src = url;
+
+    const closeButton = modal.querySelector<HTMLElement>(".admin-modal__close");
+    closeButton?.focus();
+}
+
+function closeModal() {
+    if (!(modal instanceof HTMLElement) || !modalFrame) {
+        return;
+    }
+
+    modal.classList.remove("is-open");
+    modal.setAttribute("aria-hidden", "true");
+    document.body.style.overflow = "";
+    modalFrame.src = "about:blank";
+
+    if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+    }
+}
+
+closeButtons.forEach(button => {
+    button.addEventListener("click", () => {
+        closeModal();
+    });
+});
+
+document.addEventListener("keydown", (event: KeyboardEvent) => {
+    if (event.key === "Escape" && modal?.classList.contains("is-open")) {
+        event.preventDefault();
+        closeModal();
+    }
+});
+
+function resolveEditUrl(target: EditTarget, trigger: HTMLElement): string | null {
+    const row = trigger.closest<HTMLTableRowElement>("tr[data-edit-url]");
+
+    if (!row) {
+        return null;
+    }
+
+    if (target === "translation") {
+        return row.dataset.translationUrl || null;
+    }
+
+    return row.dataset.editUrl || null;
+}
+
+function getModalTitle(target: EditTarget, trigger: HTMLElement): string {
+    const row = trigger.closest<HTMLTableRowElement>("tr[data-edit-url]");
+    const caseta = row?.dataset.caseta;
+    const nombre = row?.dataset.nombre;
+    const baseTitle = target === "translation" ? "Editar traducción" : "Editar puesto";
+    const details = [caseta, nombre].filter(Boolean).join(" · ");
+
+    return details ? `${baseTitle} · ${details}` : baseTitle;
+}
+
+function handleModalTrigger(trigger: HTMLElement, target: EditTarget) {
+    const url = resolveEditUrl(target, trigger);
+
+    if (!url) {
+        return;
+    }
+
+    openModal(url, getModalTitle(target, trigger));
+}
+
+const editableCells = Array.from(document.querySelectorAll<HTMLElement>(".admin-table-cell--editable"));
+
+editableCells.forEach(cell => {
+    const target = cell.dataset.editTarget as EditTarget | undefined;
+
+    if (!target) {
+        return;
+    }
+
+    cell.addEventListener("click", (event: MouseEvent) => {
+        const targetElement = event.target instanceof HTMLElement ? event.target : null;
+
+        if (targetElement?.closest("a, button")) {
+            return;
+        }
+
+        handleModalTrigger(cell, target);
+    });
+
+    cell.addEventListener("keydown", (event: KeyboardEvent) => {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            handleModalTrigger(cell, target);
+        }
+    });
+});
 
 // Cuando cargue la página, meter todas las etiquetas style en el head en una sola
 window.addEventListener("load", () => {
@@ -45,6 +160,8 @@ window.addEventListener("load", () => {
         styles.forEach(style => style.remove());
     }
 });
+
+console.log("Código TypeScript de la página de administración de puestos cargado correctamente.");
 
 export { };
 


### PR DESCRIPTION
## Summary
- allow managing stalls and translations directly from the admin index with inline modal triggers
- introduce reusable modal markup and styling for the admin dashboard
- enhance admin JavaScript/TypeScript to open the existing edit forms in an embedded iframe and keep accessibility safeguards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54e8ee2c48325b559547d5851df9c