### PR TITLE
Fix env loader compatibility with older PHP versions

### DIFF
--- a/config/env_loader.php
+++ b/config/env_loader.php
@@ -57,8 +57,12 @@ if (!function_exists('load_project_env')) {
 if (!function_exists('get_env_value')) {
     /**
      * Retrieve an environment variable. Environment variables take precedence over file values.
+     *
+     * @param string|null $default
+     *
+     * @return string|null
      */
-    function get_env_value(string $key, array $fileValues, mixed $default = null): mixed
+    function get_env_value(string $key, array $fileValues, $default = null)
     {
         $environmentValue = getenv($key);
         if ($environmentValue !== false) {


### PR DESCRIPTION
## Summary
- remove mixed parameter and return type hints from `get_env_value` to support older PHP versions
- document expected parameter and return values with phpdoc annotations

## Testing
- php -l config/env_loader.php

------
https://chatgpt.com/codex/tasks/task_e_68f77120deac8325822abe5f72c4a9d1